### PR TITLE
Add font group protocol

### DIFF
--- a/Sources/MarkdownView/Customization/Font/AnyMarkdownFontGroup.swift
+++ b/Sources/MarkdownView/Customization/Font/AnyMarkdownFontGroup.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// A type-erased MarkdownFontGroup value.
+public struct AnyMarkdownFontGroup {
+    var _h1: Font
+    var _h2: Font
+    var _h3: Font
+    var _h4: Font
+    var _h5: Font
+    var _h6: Font
+    var _codeBlock: Font
+    var _blockQuote: Font
+    var _tableHeader: Font
+    var _tableBody: Font
+    var _body: Font
+    
+    init(_ group: some MarkdownFontGroup) {
+        _h1 = group.h1
+        _h2 = group.h2
+        _h3 = group.h3
+        _h4 = group.h4
+        _h5 = group.h5
+        _h6 = group.h6
+        _codeBlock = group.codeBlock
+        _blockQuote = group.blockQuote
+        _tableHeader = group.tableHeader
+        _tableBody = group.tableBody
+        _body = group.body
+    }
+}
+
+extension AnyMarkdownFontGroup: MarkdownFontGroup {
+    public var h1: Font { _h1 }
+    public var h2: Font { _h2 }
+    public var h3: Font { _h3 }
+    public var h4: Font { _h4 }
+    public var h5: Font { _h5 }
+    public var h6: Font { _h6 }
+    public var codeBlock: Font { _codeBlock }
+    public var blockQuote: Font { _blockQuote }
+    public var tableHeader: Font { _tableHeader }
+    public var tableBody: Font { _tableBody }
+    public var body: Font { _body }
+}
+
+extension AnyMarkdownFontGroup: Equatable { }

--- a/Sources/MarkdownView/Customization/Font/DefaultFontGroup.swift
+++ b/Sources/MarkdownView/Customization/Font/DefaultFontGroup.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// The font group that describes a set of platform’s dynamic types for each component.
+///
+/// Use ``MarkdownView/MarkdownFontGroup/automatic`` to construct this type.
+public struct DefaultFontGroup: MarkdownFontGroup { }
+
+extension MarkdownFontGroup where Self == DefaultFontGroup {
+    /// The font group that describes a set of platform’s dynamic types for each component.
+    static public var automatic: DefaultFontGroup { .init() }
+}

--- a/Sources/MarkdownView/Customization/Font/Deprecated/FontProvider.swift
+++ b/Sources/MarkdownView/Customization/Font/Deprecated/FontProvider.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(*, deprecated, message: "Use MarkdownFontGroup protocol to create your font group.")
 /// A font provider that defines fonts for each type of components.
 public struct MarkdownFontProvider {
     // Headings
@@ -49,6 +50,7 @@ public struct MarkdownFontProvider {
     }
 }
 
+@available(*, deprecated)
 extension MarkdownFontProvider {
     mutating func modify(_ type: TextType, font: Font) {
         switch type {
@@ -75,36 +77,34 @@ extension MarkdownFontProvider {
     }
 }
 
+@available(*, deprecated)
 extension MarkdownFontProvider: Equatable {}
 
-struct MarkdownFontProviderKey: EnvironmentKey {
-    static var defaultValue = MarkdownFontProvider()
-}
-
-public extension EnvironmentValues {
-    var markdownFont: MarkdownFontProvider {
-        get { self[MarkdownFontProviderKey.self] }
-        set { self[MarkdownFontProviderKey.self] = newValue }
-    }
-}
-
-public extension View {
-    /// Sets the font for the specific component in MarkdownView.
-    /// - Parameters:
-    ///   - font: The font to apply to these components.
-    ///   - type: The type of components to apply the font.
-    func font(_ font: Font, for type: MarkdownFontProvider.TextType) -> some View {
-        transformEnvironment(\.markdownFont) { view in
-            view.modify(type, font: font)
-        }
-    }
+@available(*, deprecated, message: "This is a bridge for deprecated MarkdownFontProvider. These APIs will be removed from MarkdownView in the future.")
+struct MarkdownFontProviderWrapper: MarkdownFontGroup {
+    var h1 = Font.largeTitle
+    var h2 = Font.title
+    var h3 = Font.title2
+    var h4 = Font.title3
+    var h5 = Font.headline
+    var h6 = Font.headline.weight(.regular)
+    var body = Font.body
+    var codeBlock = Font.system(.callout, design: .monospaced)
+    var blockQuote = Font.system(.body, design: .serif)
+    var tableHeader = Font.headline
+    var tableBody = Font.body
     
-    /// Apply a font set to MarkdownView.
-    ///
-    /// This is useful when you want to completely customize fonts.
-    /// 
-    /// - Parameter fontProvider: A font set to apply to the MarkdownView.
-    func markdownFont(_ fontProvider: MarkdownFontProvider) -> some View {
-        environment(\.markdownFont, fontProvider)
+    init(_ provider: MarkdownFontProvider) {
+        self.h1 = provider.h1
+        self.h2 = provider.h2
+        self.h3 = provider.h3
+        self.h4 = provider.h4
+        self.h5 = provider.h5
+        self.h6 = provider.h6
+        self.body = provider.body
+        self.codeBlock = provider.codeBlock
+        self.blockQuote = provider.blockQuote
+        self.tableHeader = provider.tableHeader
+        self.tableBody = provider.tableBody
     }
 }

--- a/Sources/MarkdownView/Customization/Font/FontModifiers.swift
+++ b/Sources/MarkdownView/Customization/Font/FontModifiers.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+// MARK: - View Extensions
+
+public extension View {
+    /// Apply a font group to MarkdownView.
+    ///
+    /// Customize fonts for multiple types of text.
+    ///
+    /// - Parameter fontGroup: A font set to apply to the MarkdownView.
+    func fontGroup(_ fontGroup: some MarkdownFontGroup) -> some View {
+        environment(\.fontGroup, .init(fontGroup))
+    }
+    
+    /// Sets the font for the specific component in MarkdownView.
+    /// - Parameters:
+    ///   - font: The font to apply to these components.
+    ///   - type: The type of components to apply the font.
+    func font(_ font: Font, for type: MarkdownTextType) -> some View {
+        transformEnvironment(\.fontGroup) { group in
+            switch type {
+            case .h1: group._h1 = font
+            case .h2: group._h2 = font
+            case .h3: group._h3 = font
+            case .h4: group._h4 = font
+            case .h5: group._h5 = font
+            case .h6: group._h6 = font
+            case .body: group._body = font
+            case .blockQuote: group._blockQuote = font
+            case .codeBlock: group._codeBlock = font
+            case .tableBody: group._tableBody = font
+            case .tableHeader: group._tableHeader = font
+            }
+        }
+    }
+    
+    /// Apply a font set to MarkdownView.
+    ///
+    /// This is useful when you want to completely customize fonts.
+    ///
+    /// - Parameter fontProvider: A font set to apply to the MarkdownView.
+    @available(*, deprecated, renamed: "fontGroup", message: "Use MarkdownFontGroup and fontGroup instead.")
+    func markdownFont(_ fontProvider: MarkdownFontProvider) -> some View {
+        environment(\.fontGroup, .init(MarkdownFontProviderWrapper(fontProvider)))
+    }
+}
+
+// MARK: - Environment Values
+
+struct MarkdownFontGroupKey: EnvironmentKey {
+    static var defaultValue = AnyMarkdownFontGroup(.automatic)
+}
+
+extension EnvironmentValues {
+    var fontGroup: AnyMarkdownFontGroup {
+        get { self[MarkdownFontGroupKey.self] }
+        set { self[MarkdownFontGroupKey.self] = newValue }
+    }
+}
+
+

--- a/Sources/MarkdownView/Customization/Font/MarkdownFontGroup.swift
+++ b/Sources/MarkdownView/Customization/Font/MarkdownFontGroup.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// A type that applies font group to all MarkdownViews within a view hierarchy.
+///
+/// To configure the current font group for a view hierarchy, use the fontGroup(_:) modifier. Specify a font group that conforms to MarkdownFontGroup when creating a MarkdownVIew.
+public protocol MarkdownFontGroup {
+    // Headings
+    var h1: Font { get }
+    var h2: Font { get }
+    var h3: Font { get }
+    var h4: Font { get }
+    var h5: Font { get }
+    var h6: Font { get }
+    
+    // Normal text
+    var body: Font { get }
+    
+    // Blocks
+    var codeBlock: Font { get }
+    var blockQuote: Font { get }
+    
+    // Tables
+    var tableHeader: Font { get }
+    var tableBody: Font { get }
+}
+
+extension MarkdownFontGroup {
+    public var h1: Font { Font.largeTitle }
+    public var h2: Font { Font.title }
+    public var h3: Font { Font.title2 }
+    public var h4: Font { Font.title3 }
+    public var h5: Font { Font.headline }
+    public var h6: Font { Font.headline.weight(.regular) }
+    
+    // Normal text
+    public var body: Font { Font.body }
+    
+    // Blocks
+    public  var codeBlock: Font { Font.system(.callout, design: .monospaced) }
+    public var blockQuote: Font { Font.system(.body, design: .serif) }
+    
+    // Tables
+    public var tableHeader: Font { Font.headline }
+    public var tableBody: Font { Font.body }
+}

--- a/Sources/MarkdownView/Customization/Font/MarkdownTextType.swift
+++ b/Sources/MarkdownView/Customization/Font/MarkdownTextType.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum MarkdownTextType: Equatable, CaseIterable {
+    case h1,h2,h3,h4,h5,h6
+    case body
+    case codeBlock,blockQuote
+    case tableHeader,tableBody
+}

--- a/Sources/MarkdownView/MarkdownView.swift
+++ b/Sources/MarkdownView/MarkdownView.swift
@@ -11,7 +11,7 @@ public struct MarkdownView: View {
     
     @Environment(\.markdownRenderingMode) private var renderingMode
     @Environment(\.lineSpacing) private var lineSpacing
-    @Environment(\.markdownFont) private var fontProvider
+    @Environment(\.fontGroup) private var fontGroup
     @Environment(\.markdownViewRole) private var role
     @Environment(\.codeHighlighterTheme) private var codeHighlighterTheme
     @Environment(\.inlineCodeBlockTint) private var inlineTintColor
@@ -59,7 +59,7 @@ public struct MarkdownView: View {
         .sizeOfView($viewSize)
         .containerSize(viewSize)
         .updateCodeBlocksWhenColorSchemeChanges()
-        .font(fontProvider.body) // Default font
+        .font(fontGroup.body) // Default font
         .if(renderingMode == .optimized) { content in
             content
                 // Received a debouncedText, we need to reload MarkdownView.
@@ -105,7 +105,7 @@ extension MarkdownView {
             lineSpacing: lineSpacing,
             inlineCodeTintColor: inlineTintColor,
             blockQuoteTintColor: blockQuoteTintColor,
-            fontProvider: fontProvider,
+            fontGroup: fontGroup,
             codeBlockTheme: codeHighlighterTheme,
             foregroundStyleGroup: foregroundStyleGroup
         )

--- a/Sources/MarkdownView/Renderer/Renderer+Font.swift
+++ b/Sources/MarkdownView/Renderer/Renderer+Font.swift
@@ -27,7 +27,7 @@ extension Renderer {
     }
     
     mutating func visitHeading(_ heading: Heading) -> Result {
-        let fontProvider = configuration.fontProvider
+        let fontProvider = configuration.fontGroup
         let font: Font
         switch heading.level {
         case 1: font = fontProvider.h1

--- a/Sources/MarkdownView/Renderer/Renderer+Table.swift
+++ b/Sources/MarkdownView/Renderer/Renderer+Table.swift
@@ -16,7 +16,7 @@ extension Renderer {
                 table.head.children.map { cell in
                     GridCellContainer(alignment: (cell as! Markdown.Table.Cell).alignment) {
                         visit(cell).content
-                            .font(configuration.fontProvider.tableHeader)
+                            .font(configuration.fontGroup.tableHeader)
                             .foregroundStyle(configuration.foregroundStyleGroup.tableHeader)
                     }
                 }
@@ -26,7 +26,7 @@ extension Renderer {
                     row.children.map { cell in
                         GridCellContainer(alignment: (cell as! Markdown.Table.Cell).alignment) {
                             visit(cell).content
-                                .font(configuration.fontProvider.tableBody)
+                                .font(configuration.fontGroup.tableBody)
                                 .foregroundStyle(configuration.foregroundStyleGroup.tableBody)
                         }
                     }
@@ -47,7 +47,7 @@ extension Renderer {
     mutating func visitTableHead(_ head: Markdown.Table.Head) -> Result {
         Result {
             let contents = contents(of: head)
-            let font = configuration.fontProvider.tableHeader
+            let font = configuration.fontGroup.tableHeader
             let foregroundStyle = configuration.foregroundStyleGroup.tableHeader
             ForEach(contents.indices, id: \.self) {
                 contents[$0].content
@@ -60,7 +60,7 @@ extension Renderer {
     mutating func visitTableBody(_ body: Markdown.Table.Body) -> Result {
         Result {
             let contents = contents(of: body)
-            let font = configuration.fontProvider.tableBody
+            let font = configuration.fontGroup.tableBody
             let foregroundStyle = configuration.foregroundStyleGroup.tableBody
             ForEach(contents.indices, id: \.self) {
                 Divider()

--- a/Sources/MarkdownView/Renderer/Renderer.swift
+++ b/Sources/MarkdownView/Renderer/Renderer.swift
@@ -54,7 +54,7 @@ struct Renderer: MarkupVisitor {
         if isText {
             var attributer = LinkAttributer(
                 tint: configuration.inlineCodeTintColor,
-                font: configuration.fontProvider.body
+                font: configuration.fontGroup.body
             )
             let link = attributer.visit(link)
             return Result(SwiftUI.Text(link))
@@ -73,7 +73,7 @@ struct Renderer: MarkupVisitor {
             }
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .font(configuration.fontProvider.blockQuote)
+            .font(configuration.fontGroup.blockQuote)
             .padding(.horizontal, 20)
             .background {
                 configuration.blockQuoteTintColor

--- a/Sources/MarkdownView/Renderer/RendererConfiguration.swift
+++ b/Sources/MarkdownView/Renderer/RendererConfiguration.swift
@@ -14,7 +14,7 @@ struct RendererConfiguration: Equatable {
     var componentSpacing: CGFloat = 8
     var inlineCodeTintColor: Color
     var blockQuoteTintColor: Color
-    var fontProvider: MarkdownFontProvider
+    var fontGroup: AnyMarkdownFontGroup
     
     /// Sets the theme of the code block.
     /// For more information, please check out [raspu/Highlightr](https://github.com/raspu/Highlightr) .

--- a/Sources/MarkdownView/View/CodeBlockView.swift
+++ b/Sources/MarkdownView/View/CodeBlockView.swift
@@ -10,7 +10,7 @@ struct HighlightedCodeBlock: View {
     var code: String
     var theme: CodeHighlighterTheme
     
-    @Environment(\.markdownFont) private var font
+    @Environment(\.fontGroup) private var font
     @Environment(\.colorScheme) private var colorScheme
     @State private var attributedCode: AttributedString?
     @State private var showCopyButton = false


### PR DESCRIPTION
Add MarkdownFontGroup protocol for better experience when you want to modify multiple types of font.

## Deprecation

- The old `MarkdownFontProvider` has been deprecated.
- `markdownFont(_:)` modifier has been deprecated.

If you are using `MarkdownFontProvider`, you should migrate to `MarkdownFontGroup`.

### Example

Define your font group:

```swift
struct MyCustomFontGroup: MarkdownFontGroup {
    var h1: Font { Font.largeTitle.weight(.black) }
}
extension MarkdownFontGroup where Self == MyCustomFontGroup {
    static var custom: MyCustomFontGroup { .init() }
}
```

Attach the font group:

```swift
MarkdownView(...)
    .fontGroup(.custom)
```
