### PR TITLE
Additional Customizations for (Unordered) Lists

### DIFF
--- a/Sources/MarkdownView/Customization/Block.swift
+++ b/Sources/MarkdownView/Customization/Block.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+
+struct ComponentSpacingEnvironmentKey: EnvironmentKey {
+    static var defaultValue: CGFloat = 8
+}
+
+extension EnvironmentValues {
+    var componentSpacing: CGFloat {
+        get { self[ComponentSpacingEnvironmentKey.self] }
+        set { self[ComponentSpacingEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func componentSpacing(_ spacing: CGFloat) -> some View {
+        self.environment(\.componentSpacing, spacing)
+    }
+}
+
+
+struct ListIndentEnvironmentKey: EnvironmentKey {
+    static var defaultValue: CGFloat = 12
+}
+
+extension EnvironmentValues {
+    var listIndent: CGFloat {
+        get { self[ListIndentEnvironmentKey.self] }
+        set { self[ListIndentEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func listIndent(_ indent: CGFloat) -> some View {
+        self.environment(\.listIndent, indent)
+    }
+}
+
+
+struct UnorderedListBulletEnvironmentKey: EnvironmentKey {
+    static var defaultValue: String = "•"
+}
+
+extension EnvironmentValues {
+    var unorderedListBullet: String {
+        get { self[UnorderedListBulletEnvironmentKey.self] }
+        set { self[UnorderedListBulletEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func unorderedListBullet(_ bullet: String) -> some View {
+        self.environment(\.unorderedListBullet, bullet)
+    }
+}
+
+
+struct UnorderedListBulletFontEnvironmentKey: EnvironmentKey {
+    static var defaultValue: Font = .title2.weight(.black)
+}
+
+extension EnvironmentValues {
+    var unorderedListBulletFont: Font {
+        get { self[UnorderedListBulletFontEnvironmentKey.self] }
+        set { self[UnorderedListBulletFontEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func unorderedListBullet(_ font: Font) -> some View {
+        self.environment(\.unorderedListBulletFont, font)
+    }
+}

--- a/Sources/MarkdownView/Customization/List.swift
+++ b/Sources/MarkdownView/Customization/List.swift
@@ -1,24 +1,5 @@
 import SwiftUI
 
-
-struct ComponentSpacingEnvironmentKey: EnvironmentKey {
-    static var defaultValue: CGFloat = 8
-}
-
-extension EnvironmentValues {
-    var componentSpacing: CGFloat {
-        get { self[ComponentSpacingEnvironmentKey.self] }
-        set { self[ComponentSpacingEnvironmentKey.self] = newValue }
-    }
-}
-
-public extension View {
-    func componentSpacing(_ spacing: CGFloat) -> some View {
-        self.environment(\.componentSpacing, spacing)
-    }
-}
-
-
 struct ListIndentEnvironmentKey: EnvironmentKey {
     static var defaultValue: CGFloat = 12
 }
@@ -31,7 +12,7 @@ extension EnvironmentValues {
 }
 
 public extension View {
-    func listIndent(_ indent: CGFloat) -> some View {
+    func markdownListIndent(_ indent: CGFloat) -> some View {
         self.environment(\.listIndent, indent)
     }
 }
@@ -49,7 +30,7 @@ extension EnvironmentValues {
 }
 
 public extension View {
-    func unorderedListBullet(_ bullet: String) -> some View {
+    func markdownUnorderedListBullet(_ bullet: String) -> some View {
         self.environment(\.unorderedListBullet, bullet)
     }
 }

--- a/Sources/MarkdownView/Customization/Spacing.swift
+++ b/Sources/MarkdownView/Customization/Spacing.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ComponentSpacingEnvironmentKey: EnvironmentKey {
+    static var defaultValue: CGFloat = 8
+}
+
+extension EnvironmentValues {
+    var componentSpacing: CGFloat {
+        get { self[ComponentSpacingEnvironmentKey.self] }
+        set { self[ComponentSpacingEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func markdownComponentSpacing(_ spacing: CGFloat) -> some View {
+        self.environment(\.componentSpacing, spacing)
+    }
+}

--- a/Sources/MarkdownView/MarkdownView.swift
+++ b/Sources/MarkdownView/MarkdownView.swift
@@ -24,7 +24,6 @@ public struct MarkdownView: View {
     @Environment(\.componentSpacing) private var componentSpacing
     @Environment(\.listIndent) private var listIndent
     @Environment(\.unorderedListBullet) private var unorderedListBullet
-    @Environment(\.unorderedListBulletFont) private var unorderedListBulletFont
 
     // Update content 0.3s after the user stops entering.
     @StateObject private var contentUpdater = ContentUpdater()
@@ -121,8 +120,7 @@ extension MarkdownView {
             foregroundStyleGroup: foregroundStyleGroup,
             codeBlockTheme: codeHighlighterTheme,
             listIndent: listIndent,
-            unorderedListBullet: unorderedListBullet,
-            unorderedListBulletFont: unorderedListBulletFont
+            unorderedListBullet: unorderedListBullet
         )
     }
 }

--- a/Sources/MarkdownView/MarkdownView.swift
+++ b/Sources/MarkdownView/MarkdownView.swift
@@ -20,7 +20,12 @@ public struct MarkdownView: View {
     @Environment(\.foregroundStyleGroup) private var foregroundStyleGroup
     @Environment(\.blockDirectiveRenderer) private var blockDirectiveRenderer
     @Environment(\.imageRenderer) private var imageRenderer
-    
+
+    @Environment(\.componentSpacing) private var componentSpacing
+    @Environment(\.listIndent) private var listIndent
+    @Environment(\.unorderedListBullet) private var unorderedListBullet
+    @Environment(\.unorderedListBulletFont) private var unorderedListBulletFont
+
     // Update content 0.3s after the user stops entering.
     @StateObject private var contentUpdater = ContentUpdater()
     @State private var representedView = AnyView(EmptyView()) // RenderedView
@@ -109,11 +114,15 @@ extension MarkdownView {
         RendererConfiguration(
             role: role,
             lineSpacing: lineSpacing,
+            componentSpacing: componentSpacing,
             inlineCodeTintColor: inlineTintColor,
             blockQuoteTintColor: blockQuoteTintColor,
             fontGroup: fontGroup,
             foregroundStyleGroup: foregroundStyleGroup,
-            codeBlockTheme: codeHighlighterTheme
+            codeBlockTheme: codeHighlighterTheme,
+            listIndent: listIndent,
+            unorderedListBullet: unorderedListBullet,
+            unorderedListBulletFont: unorderedListBulletFont
         )
     }
 }

--- a/Sources/MarkdownView/Renderer/Renderer+List.swift
+++ b/Sources/MarkdownView/Renderer/Renderer+List.swift
@@ -55,7 +55,7 @@ extension Renderer {
                             CheckboxView(listItem: listItem, text: rawText, handler: handler)
                         } else {
                             SwiftUI.Text(configuration.unorderedListBullet)
-                                .font(configuration.unorderedListBulletFont)
+                                .font(.title2)
                                 .padding(.leading, depth == 0 ? configuration.listIndent : 0)
                         }
                         itemContent[index]

--- a/Sources/MarkdownView/Renderer/Renderer+List.swift
+++ b/Sources/MarkdownView/Renderer/Renderer+List.swift
@@ -21,6 +21,7 @@ extension Renderer {
             let depth = orderedList.listDepth
             let handler = interactiveEditHandler
             let rawText = text
+            let configuration = configuration
             VStack(alignment: .leading, spacing: configuration.componentSpacing) {
                 ForEach(listItems.indices, id: \.self) { index in
                     let listItem = listItems[index]
@@ -29,7 +30,7 @@ extension Renderer {
                             CheckboxView(listItem: listItem, text: rawText, handler: handler)
                         } else {
                             SwiftUI.Text("\(index + 1).")
-                                .padding(.leading, depth == 0 ? 12 : 0)
+                                .padding(.leading, depth == 0 ? configuration.listIndent : 0)
                         }
                         itemContent[index]
                     }
@@ -45,6 +46,7 @@ extension Renderer {
             let depth = unorderedList.listDepth
             let handler = interactiveEditHandler
             let rawText = text
+            let configuration = configuration
             VStack(alignment: .leading, spacing: configuration.componentSpacing) {
                 ForEach(itemContent.indices, id: \.self) { index in
                     let listItem = listItems[index]
@@ -52,10 +54,9 @@ extension Renderer {
                         if listItem.checkbox != nil {
                             CheckboxView(listItem: listItem, text: rawText, handler: handler)
                         } else {
-                            SwiftUI.Text("•")
-                                .font(.title2)
-                                .fontWeight(.black)
-                                .padding(.leading, depth == 0 ? 12 : 0)
+                            SwiftUI.Text(configuration.unorderedListBullet)
+                                .font(configuration.unorderedListBulletFont)
+                                .padding(.leading, depth == 0 ? configuration.listIndent : 0)
                         }
                         itemContent[index]
                     }

--- a/Sources/MarkdownView/Renderer/RendererConfiguration.swift
+++ b/Sources/MarkdownView/Renderer/RendererConfiguration.swift
@@ -26,5 +26,4 @@ struct RendererConfiguration: Equatable {
 
     var listIndent: CGFloat
     var unorderedListBullet: String
-    var unorderedListBulletFont: Font
 }

--- a/Sources/MarkdownView/Renderer/RendererConfiguration.swift
+++ b/Sources/MarkdownView/Renderer/RendererConfiguration.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+
+
 struct RendererConfiguration: Equatable {
     var role: MarkdownViewRole
     
@@ -11,7 +13,7 @@ struct RendererConfiguration: Equatable {
     ///     MarkdownView(...)
     ///         .lineSpacing(10)
     var lineSpacing: CGFloat
-    var componentSpacing: CGFloat = 8
+    var componentSpacing: CGFloat
     var inlineCodeTintColor: Color
     var blockQuoteTintColor: Color
     
@@ -21,4 +23,8 @@ struct RendererConfiguration: Equatable {
     /// Sets the theme of the code block.
     /// For more information, please check out [raspu/Highlightr](https://github.com/raspu/Highlightr) .
     var codeBlockTheme: CodeHighlighterTheme
+
+    var listIndent: CGFloat
+    var unorderedListBullet: String
+    var unorderedListBulletFont: Font
 }


### PR DESCRIPTION
Add the following environment values and plumb them to `Renderer` via `RendererConfiguration`. Use the existing defaults.

* `componentSpacing`: spacing between list items [default 8];
* `listIndent`: the indentation size to user for list items [default 12];
* `unorderedListBullet`: the bullet to use for list items [default "•"];
* `unorderedListBulletFont`: the font to use for `unorderedListBullet` [default: black `title2`]