### PR TITLE
Remove font attribute in CodeBlockView

### DIFF
--- a/Sources/MarkdownView/View/CodeBlockView.swift
+++ b/Sources/MarkdownView/View/CodeBlockView.swift
@@ -64,9 +64,10 @@ struct HighlightedCodeBlock: View {
         guard let highlighter = Highlightr.shared else { return }
         let language = highlighter.supportedLanguages().first(where: { $0.lowercased() == self.language?.lowercased() })
         if let highlightedCode = highlighter.highlight(code, as: language) {
-            withAnimation {
-                attributedCode = AttributedString(highlightedCode)
-            }
+            let code = NSMutableAttributedString(attributedString: highlightedCode)
+            code.removeAttribute(.font, range: NSMakeRange(0, code.length))
+
+            attributedCode = AttributedString(code)
         }
     }
 }


### PR DESCRIPTION
Before, there was a noticeable jump from unhighlighted → highlighted

https://github.com/user-attachments/assets/ce78555c-ef27-44a7-997c-689c50ebc11e

By removing the font attribute, the `.font(font.codeBlock)` modifier is respected for both highlight states. We can remove the animation because there is no longer any discontinuity.

![Highlighted swift code block](https://github.com/user-attachments/assets/5aeb3395-16e6-4b2e-9554-38b4bbd1e981)
