### PR TITLE
Update syntax highlighting when dark mode changes

### DIFF
--- a/Sources/MarkdownView/View/CodeBlockView.swift
+++ b/Sources/MarkdownView/View/CodeBlockView.swift
@@ -83,22 +83,25 @@ extension Highlightr {
 struct CodeHighlighterUpdator: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.codeHighlighterTheme) private var theme: CodeHighlighterTheme
-    
+
     func body(content: Content) -> some View {
         content
-            #if canImport(Highlightr)
-            .task(id: colorScheme) {
-                let theme = colorScheme == .dark ? theme.darkModeThemeName : theme.lightModeThemeName
-                Highlightr.shared?.setTheme(to: theme)
-            }
-            .onChange(of: theme) { newTheme in
-                let theme = colorScheme == .dark ? newTheme.darkModeThemeName : newTheme.lightModeThemeName
-                Highlightr.shared?.setTheme(to: theme)
-            }
-            #endif
+        #if canImport(Highlightr)
+        .task(id: colorScheme) {
+            let theme = colorScheme == .dark ? theme.darkModeThemeName : theme.lightModeThemeName
+            Highlightr.shared?.setTheme(to: theme)
+        }
+        .onChange(of: theme) { newTheme in
+            let theme = colorScheme == .dark ? newTheme.darkModeThemeName : newTheme.lightModeThemeName
+            Highlightr.shared?.setTheme(to: theme)
+        }
+        .onChange(of: colorScheme) { newColorTheme in
+            let theme = newColorTheme == .dark ? theme.darkModeThemeName : theme.lightModeThemeName
+            Highlightr.shared?.setTheme(to: theme)
+        }
+        #endif
     }
 }
-
 extension View {
     func updateCodeBlocksWhenColorSchemeChanges() -> some View {
         modifier(CodeHighlighterUpdator())


### PR DESCRIPTION
Currently the code block syntax highlighting changes when `CodeHighlighterTheme` is changed. However, it doesn't update when system dark mode is toggled.

I added an `.onChange(of: colorScheme)` to handle this case.