### PR TITLE
Update `DefaultCodeBlockStyle`

### DIFF
--- a/Sources/MarkdownView/Configurations/ForegroundStyle/AnyForegroundStyleGroup.swift
+++ b/Sources/MarkdownView/Configurations/ForegroundStyle/AnyForegroundStyleGroup.swift
@@ -8,7 +8,6 @@ public struct AnyMarkdownForegroundStyleGroup: Sendable {
     var _h4: AnyShapeStyle
     var _h5: AnyShapeStyle
     var _h6: AnyShapeStyle
-    var _codeBlock: AnyShapeStyle
     var _blockQuote: AnyShapeStyle
     var _tableHeader: AnyShapeStyle
     var _tableBody: AnyShapeStyle
@@ -20,7 +19,6 @@ public struct AnyMarkdownForegroundStyleGroup: Sendable {
         _h4 = AnyShapeStyle(group.h4)
         _h5 = AnyShapeStyle(group.h5)
         _h6 = AnyShapeStyle(group.h6)
-        _codeBlock = AnyShapeStyle(group.codeBlock)
         _blockQuote = AnyShapeStyle(group.blockQuote)
         _tableHeader = AnyShapeStyle(group.tableHeader)
         _tableBody = AnyShapeStyle(group.tableBody)
@@ -34,7 +32,6 @@ extension AnyMarkdownForegroundStyleGroup: MarkdownForegroundStyleGroup {
     public var h4: AnyShapeStyle { _h4 }
     public var h5: AnyShapeStyle { _h5 }
     public var h6: AnyShapeStyle { _h6 }
-    public var codeBlock: AnyShapeStyle { _codeBlock }
     public var blockQuote: AnyShapeStyle { _blockQuote }
     public var tableHeader: AnyShapeStyle { _tableHeader }
     public var tableBody: AnyShapeStyle { _tableBody }

--- a/Sources/MarkdownView/Configurations/ForegroundStyle/MarkdownStyleTarget.swift
+++ b/Sources/MarkdownView/Configurations/ForegroundStyle/MarkdownStyleTarget.swift
@@ -3,6 +3,6 @@ import Foundation
 @_documentation(visibility: internal)
 public enum MarkdownStyleTarget {
     case h1, h2, h3, h4, h5, h6
-    case codeBlock, blockQuote
+    case blockQuote
     case tableHeader, tableBody
 }

--- a/Sources/MarkdownView/Modifiers/ForegroundStyleModifier.swift
+++ b/Sources/MarkdownView/Modifiers/ForegroundStyleModifier.swift
@@ -42,7 +42,6 @@ extension View {
             case .h5: foregroundStyleGroup._h5 = erasedShapeStyle
             case .h6: foregroundStyleGroup._h6 = erasedShapeStyle
             case .blockQuote: foregroundStyleGroup._blockQuote = erasedShapeStyle
-            case .codeBlock: foregroundStyleGroup._codeBlock = erasedShapeStyle
             case .tableBody: foregroundStyleGroup._tableBody = erasedShapeStyle
             case .tableHeader: foregroundStyleGroup._tableHeader = erasedShapeStyle
             }

--- a/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
@@ -82,15 +82,15 @@ struct DefaultMarkdownCodeBlock: View {
         .lineSpacing(4)
         .font(fontGroup.codeBlock)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
+        .padding(16)
         #if os(macOS) || os(iOS)
         .safeAreaInset(edge: .top, spacing: 0) {
             copyButton
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                .background(.regularMaterial)
+                .background(.quaternary.opacity(0.3))
                 .overlay {
                     Rectangle()
-                        .stroke(.quaternary)
+                        .stroke(.quaternary, lineWidth: 0.5)
                         .scaleEffect(x: 1.5, y: 1.5, anchor: .bottom)
                 }
         }
@@ -214,7 +214,7 @@ struct DefaultMarkdownCodeBlock: View {
                         .transition(.opacity.combined(with: .scale))
                 }
             }
-            .contentShape(Rectangle())
+            .contentShape(.rect)
         }
         .buttonStyle(.accessory)
         .font(.callout.weight(.medium))

--- a/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
@@ -192,7 +192,7 @@ struct DefaultMarkdownCodeBlock: View {
             #if os(macOS)
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(codeBlockConfiguration.code, forType: .string)
-            #else
+            #elseif os(iOS) || os(visionOS)
             UIPasteboard.general.string = codeBlockConfiguration.code
             #endif
             Task {

--- a/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/Code Block/DefaultCodeBlockStyle.swift
@@ -61,9 +61,11 @@ struct DefaultMarkdownCodeBlock: View {
     
     @Environment(\.markdownRendererConfiguration.fontGroup) private var fontGroup
     
-    @State private var showCopyButton = false
     @State private var attributedCode: AttributedString?
     @State private var codeHighlightTask: Task<Void, Error>?
+    
+    @State private var showCopyButton = false
+    @State private var codeCopied = false
     
     var body: some View {
         Group {
@@ -77,23 +79,27 @@ struct DefaultMarkdownCodeBlock: View {
         .onChange(of: codeBlockConfiguration) {
             debouncedHighlight()
         }
-        .lineSpacing(5)
+        .lineSpacing(4)
         .font(fontGroup.codeBlock)
-        .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        .padding(12)
         #if os(macOS) || os(iOS)
-        .overlay(alignment: .topTrailing) {
-            if showCopyButton {
-                CopyButton(content: codeBlockConfiguration.code)
-                    .padding(8)
-                    .transition(.opacity.animation(.easeInOut))
-            }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            copyButton
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .background(.regularMaterial)
+                .overlay {
+                    Rectangle()
+                        .stroke(.quaternary)
+                        .scaleEffect(x: 1.5, y: 1.5, anchor: .bottom)
+                }
         }
-        .onHover { showCopyButton = $0 }
         #endif
-        .overlay(alignment: .bottomTrailing) {
-            codeLanguage
+        .background(.background)
+        .clipShape(.rect(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(.quaternary)
         }
     }
     
@@ -102,7 +108,6 @@ struct DefaultMarkdownCodeBlock: View {
         if let language = codeBlockConfiguration.language {
             Text(language.uppercased())
                 .font(.callout)
-                .padding(8)
                 .foregroundStyle(.secondary)
         }
     }
@@ -181,6 +186,44 @@ struct DefaultMarkdownCodeBlock: View {
         }
         #endif
     }
+    
+    private var copyButton: some View {
+        Button {
+            #if os(macOS)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(codeBlockConfiguration.code, forType: .string)
+            #else
+            UIPasteboard.general.string = codeBlockConfiguration.code
+            #endif
+            Task {
+                withAnimation(.spring()) {
+                    codeCopied = true
+                }
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+                withAnimation(.spring()) {
+                    codeCopied = false
+                }
+            }
+        } label: {
+            Group {
+                if codeCopied {
+                    Label("Copied", systemImage: "checkmark")
+                        .transition(.opacity.combined(with: .scale))
+                } else {
+                    Label("Copy", systemImage: "square.on.square")
+                        .transition(.opacity.combined(with: .scale))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.accessory)
+        .font(.callout.weight(.medium))
+        #if os(macOS)
+        .padding(8)
+        #else
+        .padding(16)
+        #endif
+    }
 }
 
 extension DefaultMarkdownCodeBlock {
@@ -197,65 +240,39 @@ extension DefaultMarkdownCodeBlock {
     }
 }
 
-// MARK: - Copy Button
+// MARK: - Supplementary
 
-#if os(macOS) || os(iOS)
-struct CopyButton: View {
-    var content: String
-    @State private var copied = false
-    #if os(macOS)
-    @ScaledMetric private var size = 12
-    #else
-    @ScaledMetric private var size = 18
-    #endif
-    @State private var isHovering = false
-    
-    var body: some View {
-        Button(action: copy) {
-            Group {
-                if copied {
-                    Image(systemName: "checkmark")
-                        .transition(.opacity.combined(with: .scale))
-                } else {
-                    Image(systemName: "doc.on.clipboard")
-                        .transition(.opacity.combined(with: .scale))
-                }
-            }
-            .font(.system(size: size))
-            .frame(width: size, height: size)
-            .padding(8)
-            .contentShape(Rectangle())
-        }
-        .foregroundStyle(.primary)
-        .background(
-            .quaternary.opacity(0.2),
-            in: RoundedRectangle(cornerRadius: 5, style: .continuous)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
-                .stroke(.quaternary, lineWidth: 1)
-        }
-        .brightness(isHovering ? 0.3 : 0)
-        .buttonStyle(.borderless) // Only use `.borderless` can behave correctly when text selection is enabled.
-        .onHover { isHovering = $0 }
-    }
-    
-    private func copy() {
+struct AccessoryButtonStyle: PrimitiveButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
         #if os(macOS)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(content, forType: .string)
-        #else
-        UIPasteboard.general.string = content
-        #endif
-        Task {
-            withAnimation(.spring()) {
-                copied = true
+        if #available(macOS 14.0, *) {
+            Button(role: configuration.role) {
+                configuration.trigger()
+            } label: {
+                configuration.label
             }
-            try await Task.sleep(nanoseconds: 2_000_000_000)
-            withAnimation(.spring()) {
-                copied = false
+            .buttonStyle(.accessoryBar)
+        } else {
+            Button(role: configuration.role) {
+                configuration.trigger()
+            } label: {
+                configuration.label
             }
+            .buttonStyle(.plain)
         }
+        #else
+        Button(role: configuration.role) {
+            configuration.trigger()
+        } label: {
+            configuration.label
+        }
+        .buttonStyle(.plain)
+        #endif
     }
 }
-#endif
+
+extension PrimitiveButtonStyle where Self == AccessoryButtonStyle {
+    static var accessory: AccessoryButtonStyle {
+        .init()
+    }
+}


### PR DESCRIPTION
Close #57 

### Updated Styles

#### macOS
<img width=360 alt="macOS dark" src="https://github.com/user-attachments/assets/ddbfefc9-a766-4e94-af4e-84019e535d7a" />
<img width=360 alt="macOS light" src="https://github.com/user-attachments/assets/f935f3aa-bf61-4e87-a9d1-c8946666bf3f" />

#### iOS

<img height=420 alt="iOS dark" src="https://github.com/user-attachments/assets/f40b13a1-1578-4f4d-b11e-4702f2950db8" />
<img height=420 alt="iOS light" src="https://github.com/user-attachments/assets/37fed970-74d2-4008-a7a5-a7844cf62311" />

