### PR TITLE
fix: iOS 15 markdown table out of range

### DIFF
--- a/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGrid.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGrid.swift
@@ -75,7 +75,9 @@ struct AdaptiveGrid: View {
                     spacing: horizontalSpacing
                 ) { col, width in
                     // Update width of cells
-                    cellSize[row * columnsCount + col] = width
+                    if row * columnsCount + col < cellSize.count {
+                        cellSize[row * columnsCount + col] = width
+                    }
                     updateLayout()
                 }
                 if showDivider && rows.count - 1 != row {

--- a/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGrid.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGrid.swift
@@ -9,9 +9,9 @@ struct AdaptiveGrid: View {
     
     private var columnsCount: Int
     // The width of each cell.
-    @State private var cellSize: [CGFloat]
+    @State private var cellSizes: [CGFloat]
     // The width of each column
-    @State private var colWidth: [CGFloat]
+    @State private var colWidths: [CGFloat]
     @State private var height = CGFloat.zero
     // The width of the whole table
     @State private var _width = CGFloat.zero
@@ -31,8 +31,8 @@ struct AdaptiveGrid: View {
         columnsCount = self.rows.reduce(0) { max($1.count, $0) }
         let sizes = [CGFloat](repeating: .zero, count: self.rows.count * columnsCount)
         // Save widths of all cells and calculate relative width for each column
-        _cellSize = State(initialValue: sizes)
-        _colWidth = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
+        _cellSizes = State(initialValue: sizes)
+        _colWidths = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
     }
     
     /// Create an adaptive grid that dynamically adjust column width to best fit the content.
@@ -50,8 +50,8 @@ struct AdaptiveGrid: View {
         columnsCount = self.rows.reduce(0) { max($1.count, $0) }
         let sizes = [CGFloat](repeating: .zero, count: self.rows.count * columnsCount)
         // Save widths of all cells and calculate relative width for each column
-        _cellSize = State(initialValue: sizes)
-        _colWidth = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
+        _cellSizes = State(initialValue: sizes)
+        _colWidths = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
     }
     
     var body: some View {
@@ -71,12 +71,13 @@ struct AdaptiveGrid: View {
             ForEach(rows.indices, id: \.self) { row in
                 AdaptiveGridRow(
                     row: rows[row],
-                    columnWidth: colWidth,
+                    columnWidths: colWidths,
                     spacing: horizontalSpacing
                 ) { col, width in
                     // Update width of cells
-                    if row * columnsCount + col < cellSize.count {
-                        cellSize[row * columnsCount + col] = width
+                    let updatingIndex = row * columnsCount + col
+                    if updatingIndex < cellSizes.count {
+                        cellSizes[updatingIndex] = width
                     }
                     updateLayout()
                 }
@@ -90,20 +91,16 @@ struct AdaptiveGrid: View {
     // Re-calculate column width for table.
     private func updateLayout() {
         var colWidth = [CGFloat](repeating: .zero, count: columnsCount)
-        for (index, size) in cellSize.enumerated() {
+        for (index, size) in cellSizes.enumerated() {
             let col = index % columnsCount // [0, (columnsCount - 1)] Represents the column index.
             if colWidth[col] < size {
                 colWidth[col] = size
             }
         }
         let spacing = max(0, (_width - colWidth.reduce(0, +)) / CGFloat(columnsCount))
-        self.colWidth = colWidth.map {
+        self.colWidths = colWidth.map {
             $0 + spacing
         }
-//        print("Spacing: \(spacing)")
-//        print("Cell Width: \(colWidth)")
-//        print("Avg spacing: \(spacing)")
-//        print("--------")
     }
 }
 

--- a/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGridRow.swift
+++ b/Sources/MarkdownView/Renderers/MarkdownView Components/AdaptiveGrid/AdaptiveGridRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct AdaptiveGridRow: View {
     var row: GridRowContainer
-    var columnWidth: [CGFloat]
+    var columnWidths: [CGFloat]
     var spacing: CGFloat?
     // Update cell width when detected
     var sizeOnChange: (_ col: Int, _ width: CGFloat) -> Void
@@ -15,12 +15,12 @@ struct AdaptiveGridRow: View {
                 
                 cell.content
                     .id(cell.id)
-                    .frame(maxWidth: columnWidth[col], alignment: alignment)
+                    .frame(maxWidth: columnWidths[col], alignment: alignment)
             }
             if row.count < columnsCount {
                 ForEach(row.count..<columnsCount, id: \.self) { index in
                     Color.clear
-                        .frame(maxWidth: columnWidth[index])
+                        .frame(maxWidth: columnWidths[index])
                         .frame(height: 1)
                 }
             }
@@ -29,7 +29,7 @@ struct AdaptiveGridRow: View {
         ._overlay { sizeDetector }
     }
     
-    private var columnsCount: Int { columnWidth.count }
+    private var columnsCount: Int { columnWidths.count }
     
     private var sizeDetector: some View {
         HStack {


### PR DESCRIPTION
When dynamic rendering stream Text, iOS 15 crash on table render.