### PR TITLE
Fix tint color of link

### DIFF
--- a/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
+++ b/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
@@ -14,6 +14,7 @@ struct MarkdownRendererConfiguration: Equatable, AllowingModifyThroughKeyPath, S
     
     var math: Math = Math()
     
+    var linkTintColor: Color = .accentColor
     var inlineCodeTintColor: Color = .accentColor
     var blockQuoteTintColor: Color = .accentColor
     var fontGroup: AnyMarkdownFontGroup = AnyMarkdownFontGroup(.automatic)

--- a/Sources/MarkdownView/Modifiers/TintColorModifier.swift
+++ b/Sources/MarkdownView/Modifiers/TintColorModifier.swift
@@ -23,6 +23,8 @@ extension View {
             environment(\.markdownRendererConfiguration.blockQuoteTintColor, tint)
         case .inlineCodeBlock:
             environment(\.markdownRendererConfiguration.inlineCodeTintColor, tint)
+        case .link:
+            environment(\.markdownRendererConfiguration.linkTintColor, tint)
         }
     }
 }
@@ -32,4 +34,5 @@ extension View {
 public enum TintableComponent {
     case blockQuote
     case inlineCodeBlock
+    case link
 }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -240,7 +240,7 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         case .text:
             return MarkdownNodeView {
                 MarkdownLink(
-                    tint: configuration.inlineCodeTintColor,
+                    tint: configuration.linkTintColor,
                     font: configuration.fontGroup.body
                 ).attributed(link)
             }


### PR DESCRIPTION
For now, link is reusing tint color of inline code, which, I think, is an unexpected behavior

A new configuration is introduced to make sure that links are correctly tinted