### PR TITLE
Customizing background style & overlay views for table rows/cells

### DIFF
--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellBackgroundStyleModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellBackgroundStyleModifier.swift
@@ -1,0 +1,82 @@
+//
+//  MarkdownTableCellBackgroundStyleModifier.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+extension View {
+    /// Sets the background style for markdown table cells within a view hierarchy.
+    ///
+    /// Use this modifier to layer a type that conforms to `Shape` protocol behind a markdown table cell. Specify a `ShapeStyle` to fill the shape.
+    ///
+    /// > Important:
+    /// >
+    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
+    /// >
+    /// > Avoid using `.padding(_:)` to adjust spacing, use `.safeAreaPadding(_:)` instead.
+    ///
+    /// Here is an example:
+    ///
+    /// ```swift
+    /// struct HighlightedTableStyle: MarkdownTableStyle {
+    ///     func makeBody(configuration: Configuration) -> some View {
+    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+    ///             configuration.header
+    ///                 .safeAreaPadding(8)
+    ///                 .markdownTableCellBackgroundStyle(.background)
+    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
+    ///                 row
+    ///                     .safeAreaPadding(8)
+    ///                     .markdownTableCellBackgroundStyle(.red.opacity(0.3), in: .rect(cornerRadius: 5))
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    nonisolated public func markdownTableCellBackgroundStyle(
+        _ background: some ShapeStyle,
+        in shape: some Shape
+    ) -> some View {
+        transformEnvironment(\.self) { environmentValues in
+            environmentValues.markdownTableCellBackgroundStyle = AnyShapeStyle(background)
+            environmentValues.markdownTableCellBackgroundShape = shape
+        }
+    }
+    
+    /// Sets the background style for markdown table cells within a view hierarchy.
+    ///
+    /// Use this modifier to place a type that conforms to the `ShapeStyle` protocol — like a `Color`, `Material`, or `HierarchicalShapeStyle` — behind a table cell.
+    ///
+    /// > Important:
+    /// >
+    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
+    /// >
+    /// > Avoid using `.padding(_:)` to adjust spacing, use `.safeAreaPadding(_:)` instead.
+    ///
+    /// Here is an example:
+    ///
+    /// ```swift
+    /// struct HighlightedTableStyle: MarkdownTableStyle {
+    ///     func makeBody(configuration: Configuration) -> some View {
+    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+    ///             configuration.header
+    ///                 .safeAreaPadding(8)
+    ///                 .markdownTableCellBackgroundStyle(.background)
+    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
+    ///                 row
+    ///                     .safeAreaPadding(8)
+    ///                     .markdownTableCellBackgroundStyle(.quatinary)
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    nonisolated public func markdownTableCellBackgroundStyle(
+        _ background: some ShapeStyle
+    ) -> some View {
+        environment(\.markdownTableCellBackgroundStyle, AnyShapeStyle(background))
+    }
+}

--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellOverlayModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellOverlayModifier.swift
@@ -1,0 +1,52 @@
+//
+//  MarkdownTableCellOverlayModifier.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+extension View {
+    /// Sets custom overlay content for markdown table cells within the view hierarchy.
+    ///
+    /// Use this modifier to add overlay decorations (e.g cell borders, etc.) to every cell within a table.
+    ///
+    /// > Important:
+    /// >
+    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
+    /// >
+    /// > Avoid using `.padding(_:)` to adjust spacing, use `.safeAreaPadding(_:)` instead.
+    ///
+    /// Here is an example:
+    ///
+    /// ```swift
+    /// struct MyTableStyle: MarkdownTableStyle {
+    ///     func makeBody(configuration: Configuration) -> some View {
+    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+    ///             configuration.header
+    ///                 .safeAreaPadding(8)
+    ///                 .markdownTableCellOverlay {
+    ///                     Rectangle()
+    ///                         .stroke()
+    ///                         .ignoresSafeArea()
+    ///                 }
+    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (_, row) in
+    ///                 row
+    ///                     .safeAreaPadding(8)
+    ///                     .markdownTableCellOverlay {
+    ///                         Rectangle()
+    ///                             .stroke()
+    ///                             .ignoresSafeArea()
+    ///                     }
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    nonisolated public func markdownTableCellOverlay<Content: View>(
+        @ViewBuilder _ content: @escaping () -> Content
+    ) -> some View {
+        environment(\.markdownTableCellOverlayContent, AnyView(content()))
+    }
+}

--- a/Sources/MarkdownView/Modifiers/MarkdownTableRowBackgroundStyleModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableRowBackgroundStyleModifier.swift
@@ -1,0 +1,82 @@
+//
+//  MarkdownTableRowBackgroundStyleModifier.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+extension View {
+    /// Sets the background style for markdown table rows within a view hierarchy.
+    ///
+    /// Use this modifier to layer a type that conforms to `Shape` protocol behind a markdown table row. Specify a `ShapeStyle` to fill the shape.
+    ///
+    /// > Important:
+    /// >
+    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
+    /// >
+    /// > Avoid using `.padding(_:)` to adjust spacing, use `.safeAreaPadding(_:)` instead.
+    ///
+    /// Here is an example:
+    ///
+    /// ```swift
+    /// struct BackgroundAlternativeTableStyle: MarkdownTableStyle {
+    ///     func makeBody(configuration: Configuration) -> some View {
+    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+    ///             configuration.header
+    ///                 .safeAreaPadding(8)
+    ///                 .markdownTableCellBackgroundStyle(.background)
+    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
+    ///                 row
+    ///                     .safeAreaPadding(8)
+    ///                     .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary), in: .rect(cornerRadius: 10))
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    nonisolated public func markdownTableRowBackgroundStyle(
+        _ background: some ShapeStyle,
+        in shape: some Shape
+    ) -> some View {
+        transformEnvironment(\.self) { environmentValues in
+            environmentValues.markdownTableRowBackgroundStyle = AnyShapeStyle(background)
+            environmentValues.markdownTableRowBackgroundShape = shape
+        }
+    }
+    
+    /// Sets the background style for markdown table rows within a view hierarchy.
+    ///
+    /// Use this modifier to place a type that conforms to the `ShapeStyle` protocol — like a `Color`, `Material`, or `HierarchicalShapeStyle` — behind a table cell.
+    ///
+    /// > Important:
+    /// >
+    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
+    /// >
+    /// > Avoid using `.padding(_:)` to adjust spacing, use `.safeAreaPadding(_:)` instead.
+    ///
+    /// Here is an example:
+    ///
+    /// ```swift
+    /// struct BackgroundAlternativeTableStyle: MarkdownTableStyle {
+    ///     func makeBody(configuration: Configuration) -> some View {
+    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
+    ///             configuration.header
+    ///                 .safeAreaPadding(8)
+    ///                 .markdownTableCellBackgroundStyle(.background)
+    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
+    ///                 row
+    ///                     .safeAreaPadding(8)
+    ///                     .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary))
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    nonisolated public func markdownTableRowBackgroundStyle(
+        _ background: some ShapeStyle
+    ) -> some View {
+        environment(\.markdownTableRowBackgroundStyle, AnyShapeStyle(background))
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableCellBackgroundStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableCellBackgroundStyle.swift
@@ -1,0 +1,28 @@
+//
+//  MarkdownTableCellBackgroundStyle.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableCellBackgroundStyleEnvironmentKey: @preconcurrency EnvironmentKey {
+    @MainActor static var defaultValue: AnyShapeStyle? = nil
+}
+
+struct MarkdownTableCellBackgroundShapeEnvironmentKey: @preconcurrency EnvironmentKey {
+    @MainActor static var defaultValue: any Shape = .rect
+}
+
+extension EnvironmentValues {
+    var markdownTableCellBackgroundStyle: AnyShapeStyle? {
+        get { self[MarkdownTableCellBackgroundStyleEnvironmentKey.self] }
+        set { self[MarkdownTableCellBackgroundStyleEnvironmentKey.self] = newValue }
+    }
+    
+    var markdownTableCellBackgroundShape: any Shape {
+        get { self[MarkdownTableCellBackgroundShapeEnvironmentKey.self] }
+        set { self[MarkdownTableCellBackgroundShapeEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableCellOverlayContent.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableCellOverlayContent.swift
@@ -1,0 +1,19 @@
+//
+//  MarkdownTableCellOverlayContent.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableCellOverlayContentEnvironmentKey: @preconcurrency EnvironmentKey {
+    @MainActor static var defaultValue: AnyView? = nil
+}
+
+extension EnvironmentValues {
+    var markdownTableCellOverlayContent: AnyView? {
+        get { self[MarkdownTableCellOverlayContentEnvironmentKey.self] }
+        set { self[MarkdownTableCellOverlayContentEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableRowBackgroundStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/Environment Keys/MarkdownTableRowBackgroundStyle.swift
@@ -1,0 +1,28 @@
+//
+//  MarkdownTableCellBackgroundStyle.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableRowBackgroundStyleEnvironmentKey: @preconcurrency EnvironmentKey {
+    @MainActor static var defaultValue: AnyShapeStyle? = nil
+}
+
+struct MarkdownTableRowBackgroundShapeEnvironmentKey: @preconcurrency EnvironmentKey {
+    @MainActor static var defaultValue: any Shape = .rect
+}
+
+extension EnvironmentValues {
+    var markdownTableRowBackgroundStyle: AnyShapeStyle? {
+        get { self[MarkdownTableRowBackgroundStyleEnvironmentKey.self] }
+        set { self[MarkdownTableRowBackgroundStyleEnvironmentKey.self] = newValue }
+    }
+    
+    var markdownTableRowBackgroundShape: any Shape {
+        get { self[MarkdownTableRowBackgroundShapeEnvironmentKey.self] }
+        set { self[MarkdownTableRowBackgroundShapeEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyle.swift
@@ -1,0 +1,39 @@
+//
+//  MarkdownTableCellStyle.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableCellStyle: Identifiable {
+    struct Position: Hashable {
+        var column: Int
+        var row: Int
+    }
+    var position: Position
+    var id: Position { position }
+    
+    var size: CGSize
+    var width: CGFloat {
+        size.width
+    }
+    var height: CGFloat {
+        size.height
+    }
+    
+    var backgroundStyle: AnyShapeStyle? = nil
+    var backgroundShape: any Shape = .rect
+    var overlayContent: AnyView? = nil
+    
+    init(position: Position, size: CGSize) {
+        self.position = position
+        self.size = size
+    }
+    
+    init(position: Position, width: CGFloat, height: CGFloat) {
+        self.position = position
+        self.size = CGSize(width: width, height: height)
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyleCollection.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyleCollection.swift
@@ -1,0 +1,96 @@
+//
+//  MarkdownTableCellStyleCollection.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+@dynamicMemberLookup
+struct MarkdownTableCellStyleCollection {
+    typealias Storage = [MarkdownTableCellStyle.Position : MarkdownTableCellStyle]
+    fileprivate var storage: Storage = [:] {
+        willSet { cacheBox.caches = [:] }
+    }
+    
+    private class CacheBox {
+        enum CacheKey: Hashable {
+            case widths
+            case heights
+            case cells
+            case offsets(MarkdownTableCellStyle.Position)
+        }
+        var caches: [CacheKey : Any] = [:]
+    }
+    private var cacheBox = CacheBox()
+    
+    subscript<T>(dynamicMember keyPath: KeyPath<Storage, T>) -> T {
+        storage[keyPath: keyPath]
+    }
+    
+    subscript(storageKey: MarkdownTableCellStyle.Position) -> MarkdownTableCellStyle? {
+        get { storage[storageKey] }
+        set { storage[storageKey] = newValue }
+    }
+    
+    var cells: [MarkdownTableCellStyle] {
+        if let cached = cacheBox.caches[.cells] {
+            return cached as! [MarkdownTableCellStyle]
+        }
+        
+        let cells = Array(storage.values)
+        cacheBox.caches[.cells] = cells
+        return cells
+    }
+    
+    var widths: [CGFloat] {
+        if let cached = cacheBox.caches[.widths] {
+            return cached as! [CGFloat]
+        }
+        
+        let columns = Set(cells.map(\.position.column)).count
+        let widths = (0..<columns).map { column in
+            cells.filter { $0.position.column == column }.map(\.width).max() ?? 0
+        }
+        cacheBox.caches[.widths] = widths
+        return widths
+    }
+    
+    var heights: [CGFloat] {
+        if let cached = cacheBox.caches[.heights] {
+            return cached as! [CGFloat]
+        }
+        
+        let rows = Set(cells.map(\.position.row)).count
+        let heights = (0..<rows).map { row in
+            cells.filter { $0.position.row == row }.map(\.height).max() ?? 0
+        }
+        cacheBox.caches[.heights] = heights
+        return heights
+    }
+    
+    func offset(for position: MarkdownTableCellStyle.Position) -> CGSize {
+        if let cached = cacheBox.caches[.offsets(position)] {
+            return cached as! CGSize
+        }
+        
+        let offset = CGSize(
+            width: widths[0..<max(0, position.column)].reduce(0, +),
+            height: heights[0..<max(0, position.row)].reduce(0, +)
+        )
+        cacheBox.caches[.offsets(position)] = offset
+        return offset
+    }
+}
+
+// MARK: - Preference Key
+
+@MainActor
+struct MarkdownTableCellStyleCollectionPreference: @preconcurrency PreferenceKey {
+    static var defaultValue: MarkdownTableCellStyleCollection = MarkdownTableCellStyleCollection()
+    
+    static func reduce(value: inout MarkdownTableCellStyleCollection, nextValue: () -> MarkdownTableCellStyleCollection) {
+        value.storage.merge(nextValue().storage, uniquingKeysWith: { $1 })
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyleTransformer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableCellStyleTransformer.swift
@@ -1,0 +1,63 @@
+//
+//  MarkdownTableCellStyleTransformer.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableCellStyleTransformer: ViewModifier {
+    var row: Int
+    var column: Int
+    
+    @Environment(\.markdownTableCellBackgroundStyle) var cellBackgroundStyle
+    @Environment(\.markdownTableCellBackgroundShape) var cellBackgroundShape
+    @Environment(\.markdownTableCellOverlayContent) var overlayContent
+    
+    @Environment(\.markdownTableRowBackgroundStyle) var rowBackgroundStyle
+    @Environment(\.markdownTableRowBackgroundShape) var rowBackgroundShape
+    
+    func body(content: Content) -> some View {
+        content.overlay {
+            GeometryReader { proxy in
+                Color.clear
+                    .accessibilityHidden(true)
+                    .allowsHitTesting(false)
+                    .transformPreference(
+                        MarkdownTableRowStyleCollectionPreference.self
+                    ) { rowStyleCollection in
+                        let position = MarkdownTableRowStyle.Position(
+                            column: column,
+                            row: row
+                        )
+                        var tableRowStyle = MarkdownTableRowStyle(
+                            position: position,
+                            idealHeight: proxy.size.height
+                        )
+                        tableRowStyle.backgroundStyle = rowBackgroundStyle
+                        tableRowStyle.backgroundShape = rowBackgroundShape
+                        rowStyleCollection[position] = tableRowStyle
+                    }
+                    .transformPreference(
+                        MarkdownTableCellStyleCollectionPreference.self
+                    ) { styleCollection in
+                        let position = MarkdownTableCellStyle.Position(
+                            column: column,
+                            row: row
+                        )
+                        var tableCellStyle = MarkdownTableCellStyle(
+                            position: position,
+                            size: proxy.size
+                        )
+                        tableCellStyle.backgroundStyle = cellBackgroundStyle
+                        tableCellStyle.backgroundShape = cellBackgroundShape
+                        tableCellStyle.overlayContent = overlayContent
+                        styleCollection[tableCellStyle.position] = tableCellStyle
+                    }
+            }
+            .ignoresSafeArea()
+        }
+    }
+}
+

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableRowStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableRowStyle.swift
@@ -1,0 +1,27 @@
+//
+//  MarkdownTableRowStyle.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+struct MarkdownTableRowStyle: Identifiable {
+    struct Position: Hashable {
+        var column: Int
+        var row: Int
+    }
+    var position: Position
+    var id: Position { position }
+    
+    var idealHeight: CGFloat
+    
+    var backgroundStyle: AnyShapeStyle? = nil
+    var backgroundShape: any Shape = .rect
+    
+    init(position: Position, idealHeight: CGFloat) {
+        self.position = position
+        self.idealHeight = idealHeight
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableRowStyleCollection.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Background & Overlay/MarkdownTableRowStyleCollection.swift
@@ -1,0 +1,82 @@
+//
+//  MarkdownTableRowStyleCollection.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+
+@dynamicMemberLookup
+struct MarkdownTableRowStyleCollection {
+    typealias Storage = [MarkdownTableRowStyle.Position : MarkdownTableRowStyle]
+    fileprivate var storage: Storage = [:] {
+        willSet { cacheBox.caches = [:] }
+    }
+    
+    private class CacheBox {
+        enum CacheKey: Hashable {
+            case heights
+            case rows
+            case offsets(MarkdownTableRowStyle.Position)
+        }
+        var caches: [CacheKey : Any] = [:]
+    }
+    private var cacheBox = CacheBox()
+    
+    subscript<T>(dynamicMember keyPath: KeyPath<Storage, T>) -> T {
+        storage[keyPath: keyPath]
+    }
+    
+    subscript(storageKey: MarkdownTableRowStyle.Position) -> MarkdownTableRowStyle? {
+        get { storage[storageKey] }
+        set { storage[storageKey] = newValue }
+    }
+    
+    var rows: [MarkdownTableRowStyle] {
+        if let cached = cacheBox.caches[.rows] {
+            return cached as! [MarkdownTableRowStyle]
+        }
+        
+        let cells = Array(storage.values)
+        cacheBox.caches[.rows] = cells
+        return cells
+    }
+    
+    var heights: [CGFloat] {
+        if let cached = cacheBox.caches[.heights] {
+            return cached as! [CGFloat]
+        }
+        
+        let rowCount = Set(rows.map(\.position.row)).count
+        let heights = (0..<rowCount).map { row in
+            rows.filter { $0.position.row == row }.map(\.idealHeight).max() ?? 0
+        }
+        cacheBox.caches[.heights] = heights
+        return heights
+    }
+    
+    func offset(for position: MarkdownTableRowStyle.Position) -> CGSize {
+        if let cached = cacheBox.caches[.offsets(position)] {
+            return cached as! CGSize
+        }
+        
+        let offset = CGSize(
+            width: 0,
+            height: heights[0..<max(0, position.row)].reduce(0, +)
+        )
+        cacheBox.caches[.offsets(position)] = offset
+        return offset
+    }
+}
+
+// MARK: - Preference Key
+
+@MainActor
+struct MarkdownTableRowStyleCollectionPreference: @preconcurrency PreferenceKey {
+    static var defaultValue: MarkdownTableRowStyleCollection = MarkdownTableRowStyleCollection()
+    
+    static func reduce(value: inout MarkdownTableRowStyleCollection, nextValue: () -> MarkdownTableRowStyleCollection) {
+        value.storage.merge(nextValue().storage, uniquingKeysWith: { $1 })
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTable.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTable.swift
@@ -4,7 +4,6 @@ import Markdown
 struct MarkdownTable: View {
     var table: Markdown.Table
     @Environment(\.markdownTableStyle) private var tableStyle
-    @Environment(\.markdownRendererConfiguration) var configuration
     
     var body: some View {
         let configuration = MarkdownTableStyleConfiguration(
@@ -15,62 +14,82 @@ struct MarkdownTable: View {
         tableStyle
             .makeBody(configuration: configuration)
             .erasedToAnyView()
+            .markdownTableCellStyleApplied()
     }
 }
 
-struct MarkdownTableHead: View {
-    var head: Markdown.Table.Head
-    
-    @Environment(\.markdownRendererConfiguration) private var configuration
-    
-    var body: some View {
-        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
-            GridRow {
-                let cells = Array(head.children) as! [Markdown.Table.Cell]
-                ForEach(Array(cells.enumerated()), id: \.offset) { (_, cell) in
-                    CmarkNodeVisitor(configuration: configuration)
-                        .makeBody(for: cell)
-                        .font(configuration.fontGroup.tableHeader)
-                        .foregroundStyle(configuration.foregroundStyleGroup.tableHeader)
-                        .multilineTextAlignment(cell.textAlignment)
+// MARK: - Auxiliary
+
+fileprivate extension View {
+    nonisolated func markdownTableCellStyleApplied() -> some View {
+        modifier(MarkdownTableCellStylingViewModifier())
+    }
+}
+
+fileprivate struct MarkdownTableCellStylingViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .backgroundPreferenceValue(
+                MarkdownTableRowStyleCollectionPreference.self
+            ) { styleCollection in
+                if styleCollection.values.contains(where: { $0.backgroundStyle != nil }) {
+                    ZStack(alignment: .topLeading) {
+                        ForEach(styleCollection.rows) { row in
+                            if let backgroundStyle = row.backgroundStyle {
+                                resolveShape(row.backgroundShape, style: backgroundStyle)
+                                    .offset(styleCollection.offset(for: row.position))
+                                    .frame(height: styleCollection.heights[row.position.row])
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
             }
-        }
-    }
-}
-
-struct MarkdownTableBody: View {
-    var tableBody: Markdown.Table.Body
-    
-    @Environment(\.markdownRendererConfiguration) private var configuration
-    
-    var body: some View {
-        ForEach(Array(tableBody.children.enumerated()), id: \.offset) { (_, row) in
-            CmarkNodeVisitor(configuration: configuration)
-                .makeBody(for: row)
-                .font(configuration.fontGroup.tableBody)
-                .foregroundStyle(configuration.foregroundStyleGroup.tableBody)
-        }
-    }
-}
-
-struct MarkdownTableRow: View {
-    var row: Markdown.Table.Row
-    
-    @Environment(\.markdownRendererConfiguration) private var configuration
-    
-    var body: some View {
-        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
-            let cells = Array(row.children) as! [Markdown.Table.Cell]
-            GridRow {
-                ForEach(Array(cells.enumerated()), id: \.offset) { (_, cell) in
-                    CmarkNodeVisitor(configuration: configuration)
-                        .makeBody(for: cell)
-                        .multilineTextAlignment(cell.textAlignment)
-                        .gridColumnAlignment(cell.horizontalAlignment)
-                        .gridCellColumns(Int(cell.colspan))
+            .backgroundPreferenceValue(
+                MarkdownTableCellStyleCollectionPreference.self
+            ) { styleCollection in
+                if styleCollection.cells.contains(where: { $0.backgroundStyle != nil }) {
+                    ZStack(alignment: .topLeading) {
+                        ForEach(styleCollection.cells) { cell in
+                            if let backgroundStyle = cell.backgroundStyle {
+                                resolveShape(cell.backgroundShape, style: backgroundStyle)
+                                    .offset(styleCollection.offset(for: cell.position))
+                                    .frame(
+                                        width: styleCollection.widths[cell.position.column],
+                                        height: styleCollection.heights[cell.position.row]
+                                    )
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
             }
+            .overlayPreferenceValue(
+                MarkdownTableCellStyleCollectionPreference.self
+            ) { styleCollection in
+                if styleCollection.cells.contains(where: { $0.overlayContent != nil }) {
+                    ZStack(alignment: .topLeading) {
+                        ForEach(styleCollection.cells) { cell in
+                            if let overlayContent = cell.overlayContent {
+                                overlayContent
+                                    .offset(styleCollection.offset(for: cell.position))
+                                    .frame(
+                                        width: styleCollection.widths[cell.position.column],
+                                        height: styleCollection.heights[cell.position.row]
+                                    )
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
+            }
+    }
+    
+    func resolveShape(_ shape: any Shape, style: some ShapeStyle) -> AnyView {
+        func cast(_ shape: some Shape) -> AnyView {
+            AnyView(shape.fill(style))
         }
+        return _openExistential(shape, do: cast(_:))
     }
 }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableBody.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableBody.swift
@@ -1,0 +1,24 @@
+//
+//  MarkdownTableBody.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+import Markdown
+
+struct MarkdownTableBody: View {
+    var tableBody: Markdown.Table.Body
+    
+    @Environment(\.markdownRendererConfiguration) private var configuration
+    
+    var body: some View {
+        ForEach(Array(tableBody.children.enumerated()), id: \.offset) { (_, row) in
+            CmarkNodeVisitor(configuration: configuration)
+                .makeBody(for: row)
+                .font(configuration.fontGroup.tableBody)
+                .foregroundStyle(configuration.foregroundStyleGroup.tableBody)
+        }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableHead.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableHead.swift
@@ -1,0 +1,36 @@
+//
+//  MarkdownTableHead.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+import Markdown
+
+struct MarkdownTableHead: View {
+    var head: Markdown.Table.Head
+    
+    @Environment(\.markdownRendererConfiguration) private var configuration
+    
+    var body: some View {
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            GridRow {
+                let cells = Array(head.children) as! [Markdown.Table.Cell]
+                ForEach(Array(cells.enumerated()), id: \.offset) { (index, cell) in
+                    CmarkNodeVisitor(configuration: configuration)
+                        .makeBody(for: cell)
+                        .font(configuration.fontGroup.tableHeader)
+                        .foregroundStyle(configuration.foregroundStyleGroup.tableHeader)
+                        .multilineTextAlignment(cell.textAlignment)
+                        .modifier(
+                            MarkdownTableCellStyleTransformer(
+                                row: 0,
+                                column: index
+                            )
+                        )
+                }
+            }
+        }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
@@ -1,0 +1,37 @@
+//
+//  MarkdownTableRow.swift
+//  MarkdownView
+//
+//  Created by Yanan Li on 2025/4/18.
+//
+
+import SwiftUI
+import Markdown
+
+struct MarkdownTableRow: View {
+    var row: Markdown.Table.Row
+    
+    @Environment(\.markdownRendererConfiguration) private var configuration
+    @Environment(\.markdownTableCellBackgroundStyle) private var backgroundStyle
+    
+    var body: some View {
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            let cells = Array(row.children) as! [Markdown.Table.Cell]
+            GridRow {
+                ForEach(Array(cells.enumerated()), id: \.offset) { (index, cell) in
+                    CmarkNodeVisitor(configuration: configuration)
+                        .makeBody(for: cell)
+                        .multilineTextAlignment(cell.textAlignment)
+                        .gridColumnAlignment(cell.horizontalAlignment)
+                        .gridCellColumns(Int(cell.colspan))
+                        .modifier(
+                            MarkdownTableCellStyleTransformer(
+                                row: row.indexInParent + /* head */ 1,
+                                column: index
+                            )
+                        )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Expand table customization capabilities once again by:
- `markdownTableRowBackgroundStyle(_:)`
- `markdownTableCellBackgroundStyle(_:)`
- `markdownTableCellOverlay(_:)`

### Example

```swift
struct BackgroundAlternativeTableStyle: MarkdownTableStyle {
    func makeBody(configuration: Configuration) -> some View {
        Grid(horizontalSpacing: 0, verticalSpacing: 0) {
            configuration.header
                .safeAreaPadding(8)
                .markdownTableRowBackgroundStyle(.background.secondary, in: .rect(cornerRadius: 8))
            ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
                row
                    .safeAreaPadding(8)
                    .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary), in: .rect(cornerRadius: 8))
            }
        }
        .overlay {
            RoundedRectangle(cornerRadius: 5)
                .stroke(.quaternary)
        }
    }
}
```

#### Screenshot

<img width="555" alt="截屏2025-04-18 22 03 26" src="https://github.com/user-attachments/assets/c7b178f0-fafc-4dd2-89df-0e7272f6d5b1" />
