### PR TITLE
Fix table cell auxiliary view misalignment

### DIFF
--- a/Sources/MarkdownView/Extensions/SwiftUI/View++.swift
+++ b/Sources/MarkdownView/Extensions/SwiftUI/View++.swift
@@ -28,22 +28,22 @@ extension View {
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             safeAreaPadding(edges, length)
         } else {
-            safeAreaInset(edge: .top) {
+            safeAreaInset(edge: .top, spacing: 0) {
                 EmptyView()
                     .frame(width: 0, height: 0)
                     .padding(.top, edges.contains(.top) ? length : 0)
             }
-            .safeAreaInset(edge: .bottom) {
+            .safeAreaInset(edge: .bottom, spacing: 0) {
                 EmptyView()
                     .frame(width: 0, height: 0)
                     .padding(.bottom, edges.contains(.bottom) ? length : 0)
             }
-            .safeAreaInset(edge: .leading) {
+            .safeAreaInset(edge: .leading, spacing: 0) {
                 EmptyView()
                     .frame(width: 0, height: 0)
                     .padding(.leading, edges.contains(.leading) ? length : 0)
             }
-            .safeAreaInset(edge: .trailing) {
+            .safeAreaInset(edge: .trailing, spacing: 0) {
                 EmptyView()
                     .frame(width: 0, height: 0)
                     .padding(.trailing, edges.contains(.trailing) ? length : 0)

--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellBackgroundStyleModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellBackgroundStyleModifier.swift
@@ -12,30 +12,7 @@ extension View {
     ///
     /// Use this modifier to layer a type that conforms to `Shape` protocol behind a markdown table cell. Specify a `ShapeStyle` to fill the shape.
     ///
-    /// > Important:
-    /// >
-    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
-    /// >
-    /// > Avoid using `.padding(_:)` to adjust spacing, use `.markdownTableCellPadding(_:)` instead.
-    ///
-    /// Here is an example:
-    ///
-    /// ```swift
-    /// struct HighlightedTableStyle: MarkdownTableStyle {
-    ///     func makeBody(configuration: Configuration) -> some View {
-    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
-    ///             configuration.header
-    ///                 .markdownTableCellPadding(8)
-    ///                 .markdownTableCellBackgroundStyle(.background)
-    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
-    ///                 row
-    ///                     .markdownTableCellPadding(8)
-    ///                     .markdownTableCellBackgroundStyle(.red.opacity(0.3), in: .rect(cornerRadius: 5))
-    ///             }
-    ///         }
-    ///     }
-    /// }
-    /// ```
+    /// - SeeAlso: To set background style for an entire row, use ``SwiftUICore/View/markdownTableRowBackgroundStyle(_:in:)``.
     nonisolated public func markdownTableCellBackgroundStyle(
         _ background: some ShapeStyle,
         in shape: some Shape
@@ -50,30 +27,7 @@ extension View {
     ///
     /// Use this modifier to place a type that conforms to the `ShapeStyle` protocol — like a `Color`, `Material`, or `HierarchicalShapeStyle` — behind a table cell.
     ///
-    /// > Important:
-    /// >
-    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
-    /// >
-    /// > Avoid using `.padding(_:)` to adjust spacing, use `.markdownTableCellPadding(_:)` instead.
-    ///
-    /// Here is an example:
-    ///
-    /// ```swift
-    /// struct HighlightedTableStyle: MarkdownTableStyle {
-    ///     func makeBody(configuration: Configuration) -> some View {
-    ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
-    ///             configuration.header
-    ///                 .markdownTableCellPadding(8)
-    ///                 .markdownTableCellBackgroundStyle(.background)
-    ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
-    ///                 row
-    ///                     .markdownTableCellPadding(8)
-    ///                     .markdownTableCellBackgroundStyle(.quatinary)
-    ///             }
-    ///         }
-    ///     }
-    /// }
-    /// ```
+    /// - SeeAlso: To set background style for an entire row, use ``SwiftUICore/View/markdownTableRowBackgroundStyle(_:)``.
     nonisolated public func markdownTableCellBackgroundStyle(
         _ background: some ShapeStyle
     ) -> some View {

--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellOverlayModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellOverlayModifier.swift
@@ -12,20 +12,13 @@ extension View {
     ///
     /// Use this modifier to add overlay decorations (e.g cell borders, etc.) to every cell within a table.
     ///
-    /// > Important:
-    /// >
-    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
-    /// >
-    /// > Avoid using `.padding(_:)` to adjust spacing, use `.markdownTableCellPadding(_:)` instead.
-    ///
-    /// Here is an example:
+    /// In this example, we add borders to each cell and set cell padding:
     ///
     /// ```swift
-    /// struct MyTableStyle: MarkdownTableStyle {
+    /// struct GridTableStyle: MarkdownTableStyle {
     ///     func makeBody(configuration: Configuration) -> some View {
     ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
     ///             configuration.header
-    ///                 .markdownTableCellPadding(8)
     ///                 .markdownTableCellOverlay {
     ///                     Rectangle()
     ///                         .stroke()
@@ -33,7 +26,6 @@ extension View {
     ///                 }
     ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (_, row) in
     ///                 row
-    ///                     .markdownTableCellPadding(8)
     ///                     .markdownTableCellOverlay {
     ///                         Rectangle()
     ///                             .stroke()
@@ -41,6 +33,7 @@ extension View {
     ///                     }
     ///             }
     ///         }
+    ///         .markdownTableCellPadding(8)
     ///     }
     /// }
     /// ```

--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellPaddingModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellPaddingModifier.swift
@@ -10,9 +10,11 @@ import SwiftUI
 extension View {
     /// Sets paddings for individual markdown table cell within the view hierarchy.
     ///
-    /// Make sure to set `horizontalSpacing` & `verticalSpacing` of a Grid or other layout stacks (e.g. `VStack`) to `0` if you use this modifier.
+    /// > tip:
+    /// > Make sure to set `horizontalSpacing` & `verticalSpacing` of a `Grid` or other layout stacks (e.g. `VStack`) to `0` to avoid extra spacings.
     ///
-    /// Here is an example:
+    /// In this example, we add background for header row and set cell padding.
+    ///
     ///
     /// ```swift
     /// struct MyTableStyle: MarkdownTableStyle {
@@ -28,6 +30,8 @@ extension View {
     ///     }
     /// }
     /// ```
+    ///
+    /// You can use `.padding(_:)` for `header` and `row` since this will apply to all cells within the scope, but it's still recomended to use ``SwiftUICore/View/markdownTableCellPadding(_:_:)`` for this purpose.
     nonisolated public func markdownTableCellPadding(
         _ edges: Edge.Set = .all,
         _ amount: CGFloat

--- a/Sources/MarkdownView/Modifiers/MarkdownTableRowBackgroundStyleModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableRowBackgroundStyleModifier.swift
@@ -12,27 +12,20 @@ extension View {
     ///
     /// Use this modifier to layer a type that conforms to `Shape` protocol behind a markdown table row. Specify a `ShapeStyle` to fill the shape.
     ///
-    /// > Important:
-    /// >
-    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
-    /// >
-    /// > Avoid using `.padding(_:)` to adjust spacing, use `.markdownTableCellPadding(_:)` instead.
-    ///
-    /// Here is an example:
+    /// Here is an example showing how to implement an alternative background table style:
     ///
     /// ```swift
-    /// struct BackgroundAlternativeTableStyle: MarkdownTableStyle {
+    /// struct AlternativeBackgroundTableStyle: MarkdownTableStyle {
     ///     func makeBody(configuration: Configuration) -> some View {
     ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
     ///             configuration.header
-    ///                 .markdownTableCellPadding(8)
     ///                 .markdownTableCellBackgroundStyle(.background)
     ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
     ///                 row
-    ///                     .markdownTableCellPadding(8)
-    ///                     .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary), in: .rect(cornerRadius: 10))
+    ///                     .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary))
     ///             }
     ///         }
+    ///         .markdownTableCellPadding(8)
     ///     }
     /// }
     /// ```
@@ -50,27 +43,20 @@ extension View {
     ///
     /// Use this modifier to place a type that conforms to the `ShapeStyle` protocol — like a `Color`, `Material`, or `HierarchicalShapeStyle` — behind a table cell.
     ///
-    /// > Important:
-    /// >
-    /// > You should set `horizontalSpacing` and `verticalSpacing` to `0` and add spacing between cells manually.
-    /// >
-    /// > Avoid using `.padding(_:)` to adjust spacing, use `.markdownTableCellPadding(_:)` instead.
-    ///
-    /// Here is an example:
+    /// Here is an example showing how to implement an alternative background table style:
     ///
     /// ```swift
-    /// struct BackgroundAlternativeTableStyle: MarkdownTableStyle {
+    /// struct AlternativeBackgroundTableStyle: MarkdownTableStyle {
     ///     func makeBody(configuration: Configuration) -> some View {
     ///         Grid(horizontalSpacing: 0, verticalSpacing: 0) {
     ///             configuration.header
-    ///                 .markdownTableCellPadding(8)
     ///                 .markdownTableCellBackgroundStyle(.background)
     ///             ForEach(Array(configuration.rows.enumerated()), id: \.offset) { (index, row) in
     ///                 row
-    ///                     .markdownTableCellPadding(8)
     ///                     .markdownTableRowBackgroundStyle(index % 2 == 0 ? AnyShapeStyle(.background) : AnyShapeStyle(.background.secondary))
     ///             }
     ///         }
+    ///         .markdownTableCellPadding(8)
     ///     }
     /// }
     /// ```

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownCellPaddingModifier.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownCellPaddingModifier.swift
@@ -16,7 +16,7 @@ extension View {
 struct MarkdownCellPaddingModifier: ViewModifier {
     var padding: MarkdownTableCellPadding
     
-    package func body(content: Content) -> some View {
+    func body(content: Content) -> some View {
         content
             .contentPadding(.top, padding[.top])
             .contentPadding(.bottom, padding[.bottom])

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableCellStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableCellStyle.swift
@@ -15,25 +15,20 @@ struct MarkdownTableCellStyle: Identifiable {
     var position: Position
     var id: Position { position }
     
-    var size: CGSize
+    var rect: CGRect
     var width: CGFloat {
-        size.width
+        rect.width
     }
     var height: CGFloat {
-        size.height
+        rect.height
     }
     
     var backgroundStyle: AnyShapeStyle? = nil
     var backgroundShape: any Shape = .rect
     var overlayContent: AnyView? = nil
     
-    init(position: Position, size: CGSize) {
+    init(position: Position, rect: CGRect) {
         self.position = position
-        self.size = size
-    }
-    
-    init(position: Position, width: CGFloat, height: CGFloat) {
-        self.position = position
-        self.size = CGSize(width: width, height: height)
+        self.rect = rect
     }
 }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableCellStyleTransformer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableCellStyleTransformer.swift
@@ -11,17 +11,19 @@ struct MarkdownTableCellStyleTransformer: ViewModifier {
     var row: Int
     var column: Int
     
-    @Environment(\.markdownTableCellBackgroundStyle) var cellBackgroundStyle
-    @Environment(\.markdownTableCellBackgroundShape) var cellBackgroundShape
-    @Environment(\.markdownTableCellOverlayContent) var overlayContent
+    @Environment(\.markdownTableCellBackgroundStyle) private var cellBackgroundStyle
+    @Environment(\.markdownTableCellBackgroundShape) private var cellBackgroundShape
+    @Environment(\.markdownTableCellOverlayContent) private var overlayContent
     
-    @Environment(\.markdownTableRowBackgroundStyle) var rowBackgroundStyle
-    @Environment(\.markdownTableRowBackgroundShape) var rowBackgroundShape
+    @Environment(\.markdownTableRowBackgroundStyle) private var rowBackgroundStyle
+    @Environment(\.markdownTableRowBackgroundShape) private var rowBackgroundShape
     
     func body(content: Content) -> some View {
         content.overlay {
             GeometryReader { proxy in
-                Color.clear
+                let rect = proxy.frame(in: .named(MarkdownTable.CoordinateSpaceName))
+                Rectangle()
+                    .fill(.clear)
                     .accessibilityHidden(true)
                     .allowsHitTesting(false)
                     .transformPreference(
@@ -33,7 +35,8 @@ struct MarkdownTableCellStyleTransformer: ViewModifier {
                         )
                         var tableRowStyle = MarkdownTableRowStyle(
                             position: position,
-                            idealHeight: proxy.size.height
+                            minY: rect.minY,
+                            maxY: rect.maxY
                         )
                         tableRowStyle.backgroundStyle = rowBackgroundStyle
                         tableRowStyle.backgroundShape = rowBackgroundShape
@@ -48,7 +51,7 @@ struct MarkdownTableCellStyleTransformer: ViewModifier {
                         )
                         var tableCellStyle = MarkdownTableCellStyle(
                             position: position,
-                            size: proxy.size
+                            rect: rect
                         )
                         tableCellStyle.backgroundStyle = cellBackgroundStyle
                         tableCellStyle.backgroundShape = cellBackgroundShape
@@ -56,6 +59,7 @@ struct MarkdownTableCellStyleTransformer: ViewModifier {
                         styleCollection[tableCellStyle.position] = tableCellStyle
                     }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .ignoresSafeArea()
         }
     }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableRowStyle.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableRowStyle.swift
@@ -15,13 +15,15 @@ struct MarkdownTableRowStyle: Identifiable {
     var position: Position
     var id: Position { position }
     
-    var idealHeight: CGFloat
+    var minY: CGFloat
+    var maxY: CGFloat
     
     var backgroundStyle: AnyShapeStyle? = nil
     var backgroundShape: any Shape = .rect
     
-    init(position: Position, idealHeight: CGFloat) {
+    init(position: Position, minY: CGFloat, maxY: CGFloat) {
         self.position = position
-        self.idealHeight = idealHeight
+        self.minY = minY
+        self.maxY = maxY
     }
 }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableRowStyleCollection.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableRowStyleCollection.swift
@@ -16,6 +16,8 @@ struct MarkdownTableRowStyleCollection {
     
     private class CacheBox {
         enum CacheKey: Hashable {
+            case minYs
+            case maxYs
             case heights
             case rows
             case offsets(MarkdownTableRowStyle.Position)
@@ -43,27 +45,59 @@ struct MarkdownTableRowStyleCollection {
         return cells
     }
     
+    var minYs: [CGFloat] {
+        if let cached = cacheBox.caches[.minYs] {
+            return cached as! [CGFloat]
+        }
+        
+        let rowCount = Set(rows.map(\.position.row)).count
+        let minYs = (0..<rowCount).map { row in
+            rows.filter { $0.position.row == row }.map(\.minY).min() ?? 0
+        }
+        cacheBox.caches[.minYs] = minYs
+        return minYs
+    }
+    
+    var maxYs: [CGFloat] {
+        if let cached = cacheBox.caches[.maxYs] {
+            return cached as! [CGFloat]
+        }
+        
+        let rowCount = Set(rows.map(\.position.row)).count
+        let maxYs = (0..<rowCount).map { row in
+            rows.filter { $0.position.row == row }.map(\.maxY).max() ?? 0
+        }
+        cacheBox.caches[.maxYs] = maxYs
+        return maxYs
+    }
+    
     var heights: [CGFloat] {
         if let cached = cacheBox.caches[.heights] {
             return cached as! [CGFloat]
         }
         
-        let rowCount = Set(rows.map(\.position.row)).count
-        let heights = (0..<rowCount).map { row in
-            rows.filter { $0.position.row == row }.map(\.idealHeight).max() ?? 0
+        let normalHeights = zip(maxYs, minYs).map(-)
+        
+        var heights = normalHeights
+        let additionalHeights = zip(minYs.dropFirst(), maxYs.dropLast()).map(-)
+        
+        for (index, additionalHeight) in additionalHeights.enumerated() {
+            heights[index] += additionalHeight
         }
         cacheBox.caches[.heights] = heights
         return heights
     }
     
     func offset(for position: MarkdownTableRowStyle.Position) -> CGSize {
+        guard storage[position] != nil else { return .zero }
+        
         if let cached = cacheBox.caches[.offsets(position)] {
             return cached as! CGSize
         }
         
         let offset = CGSize(
             width: 0,
-            height: heights[0..<max(0, position.row)].reduce(0, +)
+            height: minYs[position.row]
         )
         cacheBox.caches[.offsets(position)] = offset
         return offset

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTable.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTable.swift
@@ -15,7 +15,12 @@ struct MarkdownTable: View {
             .makeBody(configuration: configuration)
             .erasedToAnyView()
             .markdownTableCellStyleApplied()
+            .coordinateSpace(name: MarkdownTable.CoordinateSpaceName)
     }
+}
+
+extension MarkdownTable {
+    static let CoordinateSpaceName: String = "markdownview-table"
 }
 
 // MARK: - Auxiliary

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableHead.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableHead.swift
@@ -21,10 +21,10 @@ struct MarkdownTableHead: View {
                 ForEach(Array(cells.enumerated()), id: \.offset) { (index, cell) in
                     CmarkNodeVisitor(configuration: configuration)
                         .makeBody(for: cell)
-                        ._markdownCellPadding(padding)
                         .font(configuration.fontGroup.tableHeader)
                         .foregroundStyle(configuration.foregroundStyleGroup.tableHeader)
                         .multilineTextAlignment(cell.textAlignment)
+                        ._markdownCellPadding(padding)
                         .modifier(
                             MarkdownTableCellStyleTransformer(
                                 row: 0,

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
@@ -21,10 +21,10 @@ struct MarkdownTableRow: View {
                 ForEach(Array(cells.enumerated()), id: \.offset) { (index, cell) in
                     CmarkNodeVisitor(configuration: configuration)
                         .makeBody(for: cell)
-                        ._markdownCellPadding(padding)
                         .multilineTextAlignment(cell.textAlignment)
                         .gridColumnAlignment(cell.horizontalAlignment)
                         .gridCellColumns(Int(cell.colspan))
+                        ._markdownCellPadding(padding)
                         .modifier(
                             MarkdownTableCellStyleTransformer(
                                 row: row.indexInParent + /* head */ 1,


### PR DESCRIPTION
For now, if I add background style or overlay content to a table cell, it may misaligned with the cell sometimes

We're only use cell size to draw background and overlay, but this can not handle the situation where two elements may have extra spacings (sometimes unexpected due to `Grid` layout)

Also, this fix unlocks people to use `.padding(_:)` to add spacings, but still not recommended (the docs is also updated)

### Comparison

#### Before this PR

https://github.com/user-attachments/assets/8de46fac-402b-4c1d-94a6-6f0ccae89bcc

#### After this PR
https://github.com/user-attachments/assets/59dfa077-81d0-43ac-86cb-d6027439bbd9

