### PR TITLE
Fix fallback table (aka `AdaptiveGrid`) behavior

### DIFF
--- a/Sources/MarkdownView/Modifiers/MarkdownTableCellPaddingModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownTableCellPaddingModifier.swift
@@ -62,7 +62,7 @@ extension View {
     /// }
     /// ```
     ///
-    /// You can use `.padding(_:)` for `header` and `row` since this will apply to all cells within the scope, but it's still recomended to use ``SwiftUICore/View/markdownTableCellPadding(_:_:)`` for this purpose.
+    /// You can use `.padding(_:)` for `header` and `row` since this will apply to all cells within the scope, but it's still recomended to use ``SwiftUICore/View/markdownTableCellPadding(_:)`` for this purpose.
     nonisolated public func markdownTableCellPadding(
         _ amount: CGFloat
     ) -> some View {

--- a/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGrid.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGrid.swift
@@ -29,10 +29,10 @@ struct AdaptiveGrid: View {
         self.showDivider = showDivider
         
         columnsCount = self.rows.reduce(0) { max($1.count, $0) }
-        let sizes = [CGFloat](repeating: .zero, count: self.rows.count * columnsCount)
+        let sizes = [CGFloat](repeating: .greatestFiniteMagnitude, count: self.rows.count * columnsCount)
         // Save widths of all cells and calculate relative width for each column
         _cellSizes = State(initialValue: sizes)
-        _colWidths = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
+        _colWidths = State(initialValue: [CGFloat](repeating: .greatestFiniteMagnitude, count: columnsCount))
     }
     
     /// Create an adaptive grid that dynamically adjust column width to best fit the content.
@@ -48,25 +48,13 @@ struct AdaptiveGrid: View {
         self.showDivider = showDivider
         
         columnsCount = self.rows.reduce(0) { max($1.count, $0) }
-        let sizes = [CGFloat](repeating: .zero, count: self.rows.count * columnsCount)
+        let sizes = [CGFloat](repeating: .greatestFiniteMagnitude, count: self.rows.count * columnsCount)
         // Save widths of all cells and calculate relative width for each column
         _cellSizes = State(initialValue: sizes)
-        _colWidths = State(initialValue: [CGFloat](repeating: .zero, count: columnsCount))
+        _colWidths = State(initialValue: [CGFloat](repeating: .greatestFiniteMagnitude, count: columnsCount))
     }
     
     var body: some View {
-        GeometryReader { geometryProxy in
-            tableBody
-                .heightOfView($height)
-                ._task(id: geometryProxy.size) {
-                    _width = geometryProxy.size.width
-                    updateLayout()
-                }
-        }
-        .frame(height: height)
-    }
-    
-    private var tableBody: some View {
         VStack(spacing: verticalSpacing) {
             ForEach(rows.indices, id: \.self) { row in
                 AdaptiveGridRow(
@@ -86,6 +74,15 @@ struct AdaptiveGrid: View {
                 }
             }
         }
+        .background {
+            GeometryReader { geometryProxy in
+                Color.clear
+                    ._task(id: geometryProxy.size) {
+                        _width = geometryProxy.size.width
+                        updateLayout()
+                    }
+            }
+        }
     }
     
     // Re-calculate column width for table.
@@ -97,16 +94,13 @@ struct AdaptiveGrid: View {
                 colWidth[col] = size
             }
         }
-        let spacing = max(0, (_width - colWidth.reduce(0, +)) / CGFloat(columnsCount))
-        self.colWidths = colWidth.map {
-            $0 + spacing
-        }
+        self.colWidths = colWidth
     }
 }
 
 struct AdaptiveGrid_Previews: PreviewProvider {
     static let grid = GridContainer {
-        GridRowContainer {
+        GridRowContainer(index: 0) {
             GridCellContainer {
                 Text("Cell")
             }
@@ -114,7 +108,7 @@ struct AdaptiveGrid_Previews: PreviewProvider {
                 Text("Leading")
             }
         }
-        GridRowContainer {
+        GridRowContainer(index: 1) {
             GridCellContainer {
                 Text("Cell")
             }

--- a/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGridRow.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGridRow.swift
@@ -16,6 +16,12 @@ struct AdaptiveGridRow: View {
                 cell.content
                     .id(cell.id)
                     .frame(maxWidth: columnWidths[col], alignment: alignment)
+                    .modifier(
+                        MarkdownTableCellStyleTransformer(
+                            row: row.index ?? 0,
+                            column: col
+                        )
+                    )
             }
             if row.count < columnsCount {
                 ForEach(row.count..<columnsCount, id: \.self) { index in
@@ -25,7 +31,6 @@ struct AdaptiveGridRow: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity)
         ._overlay { sizeDetector }
     }
     

--- a/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGridRow.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/AdaptiveGridRow.swift
@@ -17,7 +17,7 @@ struct AdaptiveGridRow: View {
                     .id(cell.id)
                     .frame(maxWidth: columnWidths[col], alignment: alignment)
                     .modifier(
-                        MarkdownTableCellStyleTransformer(
+                        MarkdownTableStylePreferenceSynchronizer(
                             row: row.index ?? 0,
                             column: col
                         )

--- a/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/GridContainers.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/AdaptiveGrid/GridContainers.swift
@@ -42,17 +42,20 @@ protocol GridRowProtocol {
 }
 
 struct GridRowContainer: GridRowProtocol {
+    var index: Int?
     var cells: [GridCellContainer]
     var count: Int { cells.count }
     
-    init(cells: [GridCellContainer]) {
+    init(index: Int? = nil, cells: [GridCellContainer]) {
+        self.index = index
         self.cells = cells
     }
 }
 
 extension GridRowContainer {
-    init(@GridRowBuilder _ row: () -> GridRowContainer) {
-        self = row()
+    init(index: Int, @GridRowBuilder _ row: () -> GridRowContainer) {
+        let row = row()
+        self.init(index: index, cells: row.cells)
     }
 }
 

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableStylePreferenceSynchronizer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Cell Customizations/MarkdownTableStylePreferenceSynchronizer.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct MarkdownTableCellStyleTransformer: ViewModifier {
+struct MarkdownTableStylePreferenceSynchronizer: ViewModifier {
     var row: Int
     var column: Int
     

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/MarkdownTableRow.swift
@@ -30,7 +30,7 @@ struct MarkdownTableRow: View {
                         .gridCellColumns(Int(cell.colspan))
                         ._markdownCellPadding(padding)
                         .modifier(
-                            MarkdownTableCellStyleTransformer(
+                            MarkdownTableStylePreferenceSynchronizer(
                                 row: rowIndex,
                                 column: index
                             )

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Fallback.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Fallback.swift
@@ -29,9 +29,9 @@ extension MarkdownTableStyleConfiguration.Table {
                 verticalSpacing: verticalSpacing,
                 showDivider: showsRowSeparators
             ) {
-                GridRowContainer {
+                GridRowContainer(index: 0) {
                     let cells = Array(table.head.children) as! [Markdown.Table.Cell]
-                    for (column, cell) in cells.enumerated() {
+                    for cell in cells {
                         GridCellContainer(alignment: cell.horizontalAlignment) {
                             CmarkNodeVisitor(configuration: configuration)
                                 .makeBody(for: cell)
@@ -39,19 +39,13 @@ extension MarkdownTableStyleConfiguration.Table {
                                 .foregroundStyle(configuration.foregroundStyleGroup.tableHeader)
                                 .multilineTextAlignment(cell.textAlignment)
                                 ._markdownCellPadding(padding)
-                                .modifier(
-                                    MarkdownTableCellStyleTransformer(
-                                        row: 0,
-                                        column: column
-                                    )
-                                )
                         }
                     }
                 }
                 for (rowIndex, row) in table.body.children.enumerated() {
-                    GridRowContainer {
+                    GridRowContainer(index: rowIndex + /* header */ 1) {
                         let cells = Array(row.children) as! [Markdown.Table.Cell]
-                        for (column, cell) in cells.enumerated() {
+                        for cell in cells {
                             GridCellContainer(alignment: cell.horizontalAlignment) {
                                 CmarkNodeVisitor(configuration: configuration)
                                     .makeBody(for: cell)
@@ -59,12 +53,6 @@ extension MarkdownTableStyleConfiguration.Table {
                                     .foregroundStyle(configuration.foregroundStyleGroup.tableBody)
                                     .multilineTextAlignment(cell.textAlignment)
                                     ._markdownCellPadding(padding)
-                                    .modifier(
-                                        MarkdownTableCellStyleTransformer(
-                                            row: rowIndex + 1 /* header */,
-                                            column: column
-                                        )
-                                    )
                             }
                         }
                     }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Header.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Header.swift
@@ -14,6 +14,7 @@ extension MarkdownTableStyleConfiguration.Table {
     /// On platforms that does not supports `Grid`, it would be `EmptyView`.
     public struct Header: View {
         var head: Markdown.Table.Head
+        @Environment(\.markdownRendererConfiguration.fontGroup.tableHeader) private var font
         
         init(_ head: Markdown.Table.Head) {
             self.head = head
@@ -25,6 +26,7 @@ extension MarkdownTableStyleConfiguration.Table {
                 rowIndex: 0,
                 cells: Array(head.cells)
             )
+            .font(font)
         }
     }
 }

--- a/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Row.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Tables/Protocol/Configuration/MarkdownTableStyleConfiguration.Table.Row.swift
@@ -14,6 +14,7 @@ extension MarkdownTableStyleConfiguration.Table {
     /// On platforms that does not supports `Grid`, it would be `EmptyView`.
     public struct Row: View {
         var row: Markdown.Table.Row
+        @Environment(\.markdownRendererConfiguration.fontGroup.tableBody) private var font
         
         init(_ row: Markdown.Table.Row) {
             self.row = row
@@ -25,6 +26,7 @@ extension MarkdownTableStyleConfiguration.Table {
                 rowIndex: row.indexInParent + 1 /* header */,
                 cells: Array(row.cells)
             )
+            .font(font)
         }
     }
 }


### PR DESCRIPTION
For now, fallback table (aka. `AdaptiveGrid`) will take up all available spaces in horizontal axis which may cause unexpected behavior when try to add `backgroundStyle` or `overlay` to fallback table.

After merging this PR, it should align with the `Grid` behavior, which only takes the required width

### Fallback & Grid comparison
#### Fallback
<img width="1038" alt="截屏2025-04-22 00 25 58" src="https://github.com/user-attachments/assets/e167724b-2c1f-4210-8135-6858b7315278" />

#### Grid
<img width="1038" alt="截屏2025-04-22 00 29 12" src="https://github.com/user-attachments/assets/2d262365-de2b-46de-a0fc-41b567a6e657" />
