### PR TITLE
Improve text layout performance

### DIFF
--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -30,8 +30,7 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         for markup in document.children {
             let nodeView = renderer.visit(markup)
             if let textOnCurrentNode = nodeView.asText, nodeViews.last?.contentType == .text {
-                let resolvedText = textOnCurrentNode._resolveText(in: .init())
-                nodeViews.append(MarkdownNodeView(Text("\n\(resolvedText)")))
+                nodeViews.append(MarkdownNodeView(textOnCurrentNode))
             } else {
                 nodeViews.append(nodeView)
             }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -30,7 +30,8 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         for markup in document.children {
             let nodeView = renderer.visit(markup)
             if let textOnCurrentNode = nodeView.asText, nodeViews.last?.contentType == .text {
-                nodeViews.append(MarkdownNodeView(Text("\n") + textOnCurrentNode))
+                let resolvedText = textOnCurrentNode._resolveText(in: .init())
+                nodeViews.append(MarkdownNodeView(Text("\n\(resolvedText)")))
             } else {
                 nodeViews.append(nodeView)
             }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -26,16 +26,10 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
 
     func visitDocument(_ document: Document) -> MarkdownNodeView {
         var renderer = self
-        var nodeViews = [MarkdownNodeView]()
-        for markup in document.children {
-            let nodeView = renderer.visit(markup)
-            if let textOnCurrentNode = nodeView.asText, nodeViews.last?.contentType == .text {
-                nodeViews.append(MarkdownNodeView(textOnCurrentNode))
-            } else {
-                nodeViews.append(nodeView)
-            }
+        let nodeViews = document.children.map {
+            renderer.visit($0)
         }
-        return MarkdownNodeView(nodeViews, autoLayout: false)
+        return MarkdownNodeView(nodeViews, layoutPolicy: .linebreak)
     }
     
     func defaultVisit(_ markup: Markdown.Markup) -> MarkdownNodeView {

--- a/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
@@ -25,7 +25,12 @@ struct MarkdownNodeView: View {
     }
     
     init<Content: View>(@ViewBuilder _ content: () -> Content) {
-        storage = .right(AnyView(content()))
+        let content = content()
+        if let markdownNode = content as? MarkdownNodeView {
+            storage = markdownNode.storage
+        } else {
+            storage = .right(AnyView(content))
+        }
     }
     
     var body: some View {
@@ -74,9 +79,12 @@ extension MarkdownNodeView {
             composedContents.append(MarkdownNodeView(textStorage.text))
         }
         
-        // Only contains text
         if composedContents.count == 1 {
-            self = composedContents[0]
+            if let textOnly = composedContents[0].asText {
+                storage = .left(textOnly)
+            } else {
+                storage = .right(AnyView(composedContents[0].body))
+            }
         } else {
             if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *), autoLayout {
                 let composedView = FlowLayout(verticleSpacing: 8) {

--- a/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
@@ -54,19 +54,24 @@ struct MarkdownNodeView: View {
 }
 
 extension MarkdownNodeView {
+    enum LayoutPolicy {
+        case adaptive
+        case linebreak
+    }
+    
     /// Combine adjacent views of the same type.
     /// - Parameter contents: A set of contents to combine together.
     /// - Parameter alignment: The alignment in relation to these contents.
     init(
         _ contents: [MarkdownNodeView],
         alignment: HorizontalAlignment = .leading,
-        autoLayout: Bool = true
+        layoutPolicy: LayoutPolicy = .adaptive
     ) {
         var composedContents = [MarkdownNodeView]()
         var textStorage = TextComposer()
         for content in contents {
             if case let .left(text) = content.storage {
-                if !autoLayout {
+                if layoutPolicy == .linebreak {
                     textStorage.append(Text("\n"))
                 }
                 textStorage.append(text)
@@ -89,7 +94,8 @@ extension MarkdownNodeView {
                 storage = .right(AnyView(composedContents[0].body))
             }
         } else {
-            if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *), autoLayout {
+            if layoutPolicy == .adaptive,
+               #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *) {
                 let composedView = FlowLayout(verticleSpacing: 8) {
                     ForEach(composedContents.indices, id: \.self) {
                         composedContents[$0].body

--- a/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/MarkdownNodeView.swift
@@ -66,6 +66,9 @@ extension MarkdownNodeView {
         var textStorage = TextComposer()
         for content in contents {
             if case let .left(text) = content.storage {
+                if !autoLayout {
+                    textStorage.append(Text("\n"))
+                }
                 textStorage.append(text)
             } else {
                 if textStorage.hasText {


### PR DESCRIPTION
### Related issues

- Closes #99 

### Result

https://github.com/user-attachments/assets/a72d6d21-d931-48ea-9419-69f4e6e8211a

### Investigation

To enable cross-paragraph text selection in SwiftUI, I initially introduced an extra Text("\n") between paragraphs. However, this approach significantly degrades text layout performance. It is currently unclear whether this is a SwiftUI performance bug or expected behavior.

I experimented with various newline representations, including Text("\n"), Text("\r"), and Text("\n\r"), but all exhibited similar performance issues.

~~As a workaround, I found that appending newline characters directly within the string content—rather than as separate Text views—alleviates the performance degradation.~~

As a workaround, newline characters will be added if `autoLayout` is false via `TextComposer`, then a single, composed Text will be produced so there's no Text that only contains newline characters