### PR TITLE
Fix backslash escaping to align with CommonMark

### DIFF
--- a/Sources/MarkdownView/Helpers/MarkdownContent.swift
+++ b/Sources/MarkdownView/Helpers/MarkdownContent.swift
@@ -44,13 +44,11 @@ public struct MarkdownContent: Sendable {
         self.raw = raw
         
         func parseRawContent() -> Document {
-            let expcapedRawMarkdown = raw.text
-                .replacingOccurrences(of: "\\", with: "\\\\")
             var options = ParseOptions()
             options.insert(.parseBlockDirectives)
             
             return Document(
-                parsing: expcapedRawMarkdown,
+                parsing: raw.text,
                 source: raw.source,
                 options: options
             )


### PR DESCRIPTION
Closes #122 