### PR TITLE
Dynamically adjust parsing options based on current needs

### DIFF
--- a/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
+++ b/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
@@ -21,7 +21,7 @@ struct MarkdownRendererConfiguration: Equatable, AllowingModifyThroughKeyPath, S
     var listConfiguration: MarkdownListConfiguration = MarkdownListConfiguration()
     
     var allowedImageRenderers: Set<String> = ["https", "http"]
-    var allowedBlockDirectiveRenderers: Set<String> = ["math"]
+    var allowedBlockDirectiveRenderers: Set<String> = []
 }
 
 // MARK: - SwiftUI Environment

--- a/Sources/MarkdownView/MarkdownTableOfContent.swift
+++ b/Sources/MarkdownView/MarkdownTableOfContent.swift
@@ -18,7 +18,9 @@ public struct MarkdownTableOfContent<Content: View>: View {
     
     private var headings: [MarkdownHeading] {
         var toc = TableOfContentVisitor()
-        toc.visit(markdownContent.document)
+        toc.visit(
+            markdownContent.store.documents.first ?? markdownContent.parse()
+        )
         return toc.headings
     }
     

--- a/Sources/MarkdownView/Modifiers/MathRenderingModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MathRenderingModifier.swift
@@ -14,10 +14,13 @@ extension View {
     nonisolated public func markdownMathRenderingEnabled(_ enabled: Bool = true) -> some View {
         transformEnvironment(\.markdownRendererConfiguration) { configuration in
             configuration.math.shouldRender = enabled
-            BlockDirectiveRenderers.shared.addRenderer(
-                MathBlockDirectiveRenderer(),
-                for: "math"
-            )
+            if enabled {
+                configuration.allowedBlockDirectiveRenderers.insert("math")
+                BlockDirectiveRenderers.shared.addRenderer(
+                    MathBlockDirectiveRenderer(),
+                    for: "math"
+                )
+            }
         }
     }
 }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkFirstMarkdownViewRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkFirstMarkdownViewRenderer.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Markdown
 
 struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {    
     func makeBody(
@@ -29,9 +30,14 @@ struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {
             return AnyView(cached.renderedView)
         }
         
-        let renderedView = CmarkNodeVisitor(
-            configuration: configuration
-        ).makeBody(for: content.document).erasedToAnyView()
+        var parseOptions = ParseOptions()
+        if !configuration.allowedBlockDirectiveRenderers.isEmpty {
+            parseOptions.insert(.parseBlockDirectives)
+        }
+        
+        let renderedView = CmarkNodeVisitor(configuration: configuration)
+            .makeBody(for: content.parse(options: parseOptions))
+            .erasedToAnyView()
         
         CacheStorage.shared.addCache(
             Cache(

--- a/Sources/MarkdownView/Renderers/Math/MathFirstMarkdownViewRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Math/MathFirstMarkdownViewRenderer.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Markdown
 
 struct MathFirstMarkdownViewRenderer: MarkdownViewRenderer {
     func makeBody(
@@ -16,7 +17,7 @@ struct MathFirstMarkdownViewRenderer: MarkdownViewRenderer {
         var rawText = content.raw.text
         
         var extractor = ParsingRangesExtractor()
-        extractor.visit(content.document)
+        extractor.visit(content.parse(options: ParseOptions().union(.parseBlockDirectives)))
         for range in extractor.parsableRanges(in: rawText) {
             let segment = rawText[range]
             let segmentParser = MathParser(text: segment)

--- a/Sources/MarkdownView/WIP/MarkdownTextRenderer.swift
+++ b/Sources/MarkdownView/WIP/MarkdownTextRenderer.swift
@@ -14,6 +14,6 @@ struct MarkdownTextRenderer {
     
     func renderMarkdownContent(_ markdownContent: MarkdownContent) -> MarkdownTextNode {
         var renderer = self
-        return renderer.visit(markdownContent.document)
+        return renderer.visit(markdownContent.parse())
     }
 }


### PR DESCRIPTION
Closes #129 

This PR uses dynamic document parse options instead of including `.parseBlockDirectives`

So now, `MarkdownView` uses default parsing options, except when developers explicitly call:
- `.blockDirectiveRenderer(_:for:)`
- `.markdownMathRenderingEnabled()`

The view modifiers listed above will enable `.parseBlockDirectives` again. If your markdown contains `@xxxx`, make sure you explicitly escape the `@` to make sure it shows as expected

https://github.com/user-attachments/assets/c9278c49-1473-4a99-a2ea-c13bb34058b7
