### PR TITLE
feat: add markdownLinkRenderer hook

### DIFF
--- a/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
+++ b/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
@@ -21,6 +21,14 @@ struct MarkdownRendererConfiguration: Equatable, AllowingModifyThroughKeyPath, S
     var listConfiguration: MarkdownListConfiguration = MarkdownListConfiguration()
     
     var allowedImageRenderers: Set<String> = ["https", "http"]
+    /// Custom link renderers keyed by URL scheme (or `"*"` wildcard).
+    /// Replaces the previous singleton `MarkdownLinkRenders.shared` so each
+    /// SwiftUI subtree carries its own renderer registration through the
+    /// environment — two `.markdownLinkRenderer(...)` calls in different
+    /// subtrees no longer race on a global last-writer-wins dictionary.
+    /// Dictionary keys are the allow-list; absence means the default
+    /// (Branch A) text rendering applies.
+    var linkRenderers: [String: AnyMarkdownLinkRenderer] = [:]
     var allowedBlockDirectiveRenderers: Set<String> = []
 }
 

--- a/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
+++ b/Sources/MarkdownView/Configurations/MarkdownRendererConfiguration.swift
@@ -21,14 +21,7 @@ struct MarkdownRendererConfiguration: Equatable, AllowingModifyThroughKeyPath, S
     var listConfiguration: MarkdownListConfiguration = MarkdownListConfiguration()
     
     var allowedImageRenderers: Set<String> = ["https", "http"]
-    /// Custom link renderers keyed by URL scheme (or `"*"` wildcard).
-    /// Replaces the previous singleton `MarkdownLinkRenders.shared` so each
-    /// SwiftUI subtree carries its own renderer registration through the
-    /// environment — two `.markdownLinkRenderer(...)` calls in different
-    /// subtrees no longer race on a global last-writer-wins dictionary.
-    /// Dictionary keys are the allow-list; absence means the default
-    /// (Branch A) text rendering applies.
-    var linkRenderers: [String: AnyMarkdownLinkRenderer] = [:]
+    var allowedLinkRenderers: Set<String> = []
     var allowedBlockDirectiveRenderers: Set<String> = []
 }
 

--- a/Sources/MarkdownView/Modifiers/MarkdownLinkRendererModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownLinkRendererModifier.swift
@@ -1,26 +1,13 @@
-//
-//  MarkdownLinkRendererModifier.swift
-//  MarkdownView
-//
-//  Orbit fork addition. Mirrors `MarkdownImageRendererModifier` so consumers
-//  can register a custom view for inline links.
-//
-
 import SwiftUI
 
 extension View {
-    /// Use custom renderer to render inline links.
-    ///
-    /// - parameter renderer: The renderer you created to handle link rendering.
-    /// - parameter urlScheme: A scheme for deciding which renderer to use.
-    ///   Pass `"*"` to register a wildcard renderer that handles every URL
-    ///   scheme.
     nonisolated public func markdownLinkRenderer(
         _ renderer: some MarkdownLinkRenderer,
         forURLScheme urlScheme: String
     ) -> some View {
         transformEnvironment(\.markdownRendererConfiguration) { configuration in
-            configuration.linkRenderers[urlScheme] = AnyMarkdownLinkRenderer(renderer)
+            MarkdownLinkRenderers.shared.addRenderer(renderer, forURLScheme: urlScheme)
+            configuration.allowedLinkRenderers.insert(urlScheme)
         }
     }
 }

--- a/Sources/MarkdownView/Modifiers/MarkdownLinkRendererModifier.swift
+++ b/Sources/MarkdownView/Modifiers/MarkdownLinkRendererModifier.swift
@@ -1,0 +1,26 @@
+//
+//  MarkdownLinkRendererModifier.swift
+//  MarkdownView
+//
+//  Orbit fork addition. Mirrors `MarkdownImageRendererModifier` so consumers
+//  can register a custom view for inline links.
+//
+
+import SwiftUI
+
+extension View {
+    /// Use custom renderer to render inline links.
+    ///
+    /// - parameter renderer: The renderer you created to handle link rendering.
+    /// - parameter urlScheme: A scheme for deciding which renderer to use.
+    ///   Pass `"*"` to register a wildcard renderer that handles every URL
+    ///   scheme.
+    nonisolated public func markdownLinkRenderer(
+        _ renderer: some MarkdownLinkRenderer,
+        forURLScheme urlScheme: String
+    ) -> some View {
+        transformEnvironment(\.markdownRendererConfiguration) { configuration in
+            configuration.linkRenderers[urlScheme] = AnyMarkdownLinkRenderer(renderer)
+        }
+    }
+}

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkFirstMarkdownViewRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkFirstMarkdownViewRenderer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Markdown
 
-struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {    
+struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {
     func makeBody(
         content: MarkdownContent,
         configuration: MarkdownRendererConfiguration
@@ -30,13 +30,8 @@ struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {
             return AnyView(cached.renderedView)
         }
         
-        var parseOptions = ParseOptions()
-        if !configuration.allowedBlockDirectiveRenderers.isEmpty {
-            parseOptions.insert(.parseBlockDirectives)
-        }
-        
         let renderedView = CmarkNodeVisitor(configuration: configuration)
-            .makeBody(for: content.parse(options: parseOptions))
+            .makeBody(for: content.parse(options: parseOptions(for: configuration)))
             .erasedToAnyView()
         
         CacheStorage.shared.addCache(
@@ -48,6 +43,16 @@ struct CmarkFirstMarkdownViewRenderer: MarkdownViewRenderer {
         )
         
         return renderedView
+    }
+}
+
+fileprivate extension CmarkFirstMarkdownViewRenderer {
+    func parseOptions(for configuration: MarkdownRendererConfiguration) -> ParseOptions {
+        var parseOptions = ParseOptions()
+        if !configuration.allowedBlockDirectiveRenderers.isEmpty {
+            parseOptions.insert(.parseBlockDirectives)
+        }
+        return parseOptions
     }
 }
 

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -12,18 +12,7 @@ import Markdown
 @preconcurrency
 struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
     var configuration: MarkdownRendererConfiguration
-
-    /// Inline emphasis (bold / italic / strikethrough) inherited from ancestor
-    /// nodes. Threaded down the visit so leaf producers that build their own
-    /// label — notably a link rendered by a custom `MarkdownLinkRenderer`, whose
-    /// output is a SwiftUI View that can't be re-styled by an ancestor — can
-    /// apply the emphasis when constructing their attributed text. Text nodes
-    /// don't need it (the ancestor merges the intent onto their runs directly).
     var activeInlineIntent: InlinePresentationIntent = []
-
-    init(configuration: MarkdownRendererConfiguration) {
-        self.configuration = configuration
-    }
     
     func makeBody(for markup: any Markup) -> some View {
         var visitor = self
@@ -211,14 +200,6 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         applyInlineIntent(.strikethrough, to: strikethrough.children)
     }
 
-    /// Merge an inline presentation intent (bold / italic / strikethrough) onto
-    /// a run of inline children. Text children receive the intent on their
-    /// attributed runs. Non-text children — e.g. a link rendered by a custom
-    /// `MarkdownLinkRenderer`, which returns a SwiftUI View that cannot carry an
-    /// `InlinePresentationIntent` — are preserved as-is rather than dropped, and
-    /// laid out alongside the text by `MarkdownNodeView`'s text+view compositor.
-    /// (Previously these children were silently skipped, so e.g. a link inside
-    /// `**bold**` disappeared entirely.)
     private func applyInlineIntent(
         _ newIntent: InlinePresentationIntent,
         to children: MarkupChildren
@@ -226,17 +207,16 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         var nodes = [MarkdownNodeView]()
         for child in children {
             var renderer = self
-            // Thread the emphasis down so view-producing descendants (e.g. a
-            // custom-rendered link) can bold/italicize their own label.
             renderer.activeInlineIntent.formUnion(newIntent)
             let node = renderer.visit(child)
             if let text = node.asAttributedString {
                 let intent = text.inlinePresentationIntent ?? []
-                nodes.append(MarkdownNodeView(
+                let attributedNode = MarkdownNodeView(
                     text.mergingAttributes(
                         AttributeContainer().inlinePresentationIntent(intent.union(newIntent))
                     )
-                ))
+                )
+                nodes.append(attributedNode)
             } else {
                 nodes.append(node)
             }
@@ -250,59 +230,24 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         else { return descendInto(link) }
 
         let nodeView = descendInto(link)
-
-        // Custom renderer dispatch (Orbit fork addition).
-        // Build defaultLabel by routing back through MarkdownNodeView so we
-        // preserve _MarkdownText's async HTML-run processing (isHTML(true)
-        // runs set by visitInlineHTML are converted via NSAttributedString
-        // HTML import in _MarkdownText.swift). Use mergingAttributes
-        // (default .keepNew) for color so it OVERRIDES any per-run
-        // foreground (e.g. visitInlineCode sets inlineCodeTintColor
-        // explicitly) — matches Branch A semantics below.
-        if let scheme = url.scheme,
-           let renderer = configuration.linkRenderers[scheme] ?? configuration.linkRenderers["*"]
-        {
-            let defaultLabel: AnyView
-            if let attrs = nodeView.asAttributedString {
-                defaultLabel = AnyView(
-                    MarkdownNodeView(
-                        attrs.mergingAttributes(
-                            AttributeContainer()
-                                .foregroundColor(configuration.linkTintColor)
-                        )
-                    )
-                )
-            } else {
-                defaultLabel = AnyView(
-                    nodeView.foregroundStyle(configuration.linkTintColor)
-                )
-            }
-            // Pass inherited emphasis (link inside **bold** / *italic* /
-            // ~~strike~~) to the renderer. The renderer owns its label's font,
-            // so it (not the library) reflects the emphasis — an
-            // `inlinePresentationIntent` attribute or `.bold()` on the label
-            // doesn't reliably render through a custom renderer's view, and a
-            // custom font's bold face must be selected explicitly.
-            let config = MarkdownLinkRendererConfiguration(
+        if let urlScheme = url.scheme,
+           configuration.allowedLinkRenderers.contains(urlScheme),
+           let renderer = MarkdownLinkRenderers.named(urlScheme) {
+            let labelContent: AnyView = nodeView
+                .foregroundStyle(configuration.linkTintColor)
+                .erasedToAnyView()
+            let linkConfiguration = MarkdownLinkRendererConfiguration(
                 url: url,
-                label: defaultLabel,
-                inlinePresentationIntent: activeInlineIntent
+                label: labelContent
             )
-            // `renderer.makeBody` is the stored closure on
-            // `AnyMarkdownLinkRenderer` and already returns `AnyView` — no
-            // explicit `.erasedToAnyView()` needed.
             return MarkdownNodeView {
-                renderer.makeBody(config)
+                renderer
+                    .makeBody(configuration: linkConfiguration)
+                    .erasedToAnyView()
+                    .foregroundStyle(self.configuration.linkTintColor)
             }
         }
 
-        // Default path — UNCHANGED for text-only links (Branch A).
-        // Note: we intentionally do NOT add .help() to Branch A.
-        // _MarkdownText wraps the whole paragraph in a single
-        // Text(AttributedString); a .help() there would apply to the entire
-        // paragraph, not per link. Per-link tooltips are only achievable
-        // via the custom-renderer path above (each link becomes its own
-        // View).
         return if let attributedString = nodeView.asAttributedString {
             MarkdownNodeView(
                 attributedString.mergingAttributes(
@@ -317,7 +262,6 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
                     nodeView
                 }
                 .foregroundStyle(configuration.linkTintColor)
-                .help(url.absoluteString)
             }
         }
     }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -237,8 +237,51 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
         guard let destination = link.destination,
               let url = URL(string: destination)
         else { return descendInto(link) }
-        
+
         let nodeView = descendInto(link)
+
+        // Custom renderer dispatch (Orbit fork addition).
+        // Build defaultLabel by routing back through MarkdownNodeView so we
+        // preserve _MarkdownText's async HTML-run processing (isHTML(true)
+        // runs set by visitInlineHTML are converted via NSAttributedString
+        // HTML import in _MarkdownText.swift). Use mergingAttributes
+        // (default .keepNew) for color so it OVERRIDES any per-run
+        // foreground (e.g. visitInlineCode sets inlineCodeTintColor
+        // explicitly) — matches Branch A semantics below.
+        if let scheme = url.scheme,
+           let renderer = configuration.linkRenderers[scheme] ?? configuration.linkRenderers["*"]
+        {
+            let defaultLabel: AnyView
+            if let attrs = nodeView.asAttributedString {
+                defaultLabel = AnyView(
+                    MarkdownNodeView(
+                        attrs.mergingAttributes(
+                            AttributeContainer()
+                                .foregroundColor(configuration.linkTintColor)
+                        )
+                    )
+                )
+            } else {
+                defaultLabel = AnyView(
+                    nodeView.foregroundStyle(configuration.linkTintColor)
+                )
+            }
+            let config = MarkdownLinkRendererConfiguration(url: url, label: defaultLabel)
+            // `renderer.makeBody` is the stored closure on
+            // `AnyMarkdownLinkRenderer` and already returns `AnyView` — no
+            // explicit `.erasedToAnyView()` needed.
+            return MarkdownNodeView {
+                renderer.makeBody(config)
+            }
+        }
+
+        // Default path — UNCHANGED for text-only links (Branch A).
+        // Note: we intentionally do NOT add .help() to Branch A.
+        // _MarkdownText wraps the whole paragraph in a single
+        // Text(AttributedString); a .help() there would apply to the entire
+        // paragraph, not per link. Per-link tooltips are only achievable
+        // via the custom-renderer path above (each link becomes its own
+        // View).
         return if let attributedString = nodeView.asAttributedString {
             MarkdownNodeView(
                 attributedString.mergingAttributes(
@@ -253,6 +296,7 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
                     nodeView
                 }
                 .foregroundStyle(configuration.linkTintColor)
+                .help(url.absoluteString)
             }
         }
     }

--- a/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
+++ b/Sources/MarkdownView/Renderers/Cmark/CmarkNodeVisitor.swift
@@ -12,7 +12,15 @@ import Markdown
 @preconcurrency
 struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
     var configuration: MarkdownRendererConfiguration
-    
+
+    /// Inline emphasis (bold / italic / strikethrough) inherited from ancestor
+    /// nodes. Threaded down the visit so leaf producers that build their own
+    /// label — notably a link rendered by a custom `MarkdownLinkRenderer`, whose
+    /// output is a SwiftUI View that can't be re-styled by an ancestor — can
+    /// apply the emphasis when constructing their attributed text. Text nodes
+    /// don't need it (the ancestor merges the intent onto their runs directly).
+    var activeInlineIntent: InlinePresentationIntent = []
+
     init(configuration: MarkdownRendererConfiguration) {
         self.configuration = configuration
     }
@@ -192,45 +200,48 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
     }
     
     func visitEmphasis(_ emphasis: Markdown.Emphasis) -> MarkdownNodeView {
-        var attributedString = AttributedString()
-        for child in emphasis.children {
-            var renderer = self
-            guard let text = renderer.visit(child).asAttributedString else { continue }
-            let intent = text.inlinePresentationIntent ?? []
-            attributedString += text.mergingAttributes(
-                AttributeContainer()
-                    .inlinePresentationIntent(intent.union(.emphasized))
-            )
-        }
-        return MarkdownNodeView(attributedString)
+        applyInlineIntent(.emphasized, to: emphasis.children)
     }
-    
+
     func visitStrong(_ strong: Strong) -> MarkdownNodeView {
-        var attributedString = AttributedString()
-        for child in strong.children {
-            var renderer = self
-            guard let text = renderer.visit(child).asAttributedString else { continue }
-            let intent = text.inlinePresentationIntent ?? []
-            attributedString += text.mergingAttributes(
-                AttributeContainer()
-                    .inlinePresentationIntent(intent.union(.stronglyEmphasized))
-            )
-        }
-        return MarkdownNodeView(attributedString)
+        applyInlineIntent(.stronglyEmphasized, to: strong.children)
     }
-    
+
     func visitStrikethrough(_ strikethrough: Strikethrough) -> MarkdownNodeView {
-        var attributedString = AttributedString()
-        for child in strikethrough.children {
+        applyInlineIntent(.strikethrough, to: strikethrough.children)
+    }
+
+    /// Merge an inline presentation intent (bold / italic / strikethrough) onto
+    /// a run of inline children. Text children receive the intent on their
+    /// attributed runs. Non-text children — e.g. a link rendered by a custom
+    /// `MarkdownLinkRenderer`, which returns a SwiftUI View that cannot carry an
+    /// `InlinePresentationIntent` — are preserved as-is rather than dropped, and
+    /// laid out alongside the text by `MarkdownNodeView`'s text+view compositor.
+    /// (Previously these children were silently skipped, so e.g. a link inside
+    /// `**bold**` disappeared entirely.)
+    private func applyInlineIntent(
+        _ newIntent: InlinePresentationIntent,
+        to children: MarkupChildren
+    ) -> MarkdownNodeView {
+        var nodes = [MarkdownNodeView]()
+        for child in children {
             var renderer = self
-            guard let text = renderer.visit(child).asAttributedString else { continue }
-            let intent = text.inlinePresentationIntent ?? []
-            attributedString += text.mergingAttributes(
-                AttributeContainer()
-                    .inlinePresentationIntent(intent.union(.strikethrough))
-            )
+            // Thread the emphasis down so view-producing descendants (e.g. a
+            // custom-rendered link) can bold/italicize their own label.
+            renderer.activeInlineIntent.formUnion(newIntent)
+            let node = renderer.visit(child)
+            if let text = node.asAttributedString {
+                let intent = text.inlinePresentationIntent ?? []
+                nodes.append(MarkdownNodeView(
+                    text.mergingAttributes(
+                        AttributeContainer().inlinePresentationIntent(intent.union(newIntent))
+                    )
+                ))
+            } else {
+                nodes.append(node)
+            }
         }
-        return MarkdownNodeView(attributedString)
+        return MarkdownNodeView(nodes)
     }
     
     mutating func visitLink(_ link: Markdown.Link) -> MarkdownNodeView {
@@ -266,7 +277,17 @@ struct CmarkNodeVisitor: @preconcurrency MarkupVisitor {
                     nodeView.foregroundStyle(configuration.linkTintColor)
                 )
             }
-            let config = MarkdownLinkRendererConfiguration(url: url, label: defaultLabel)
+            // Pass inherited emphasis (link inside **bold** / *italic* /
+            // ~~strike~~) to the renderer. The renderer owns its label's font,
+            // so it (not the library) reflects the emphasis — an
+            // `inlinePresentationIntent` attribute or `.bold()` on the label
+            // doesn't reliably render through a custom renderer's view, and a
+            // custom font's bold face must be selected explicitly.
+            let config = MarkdownLinkRendererConfiguration(
+                url: url,
+                label: defaultLabel,
+                inlinePresentationIntent: activeInlineIntent
+            )
             // `renderer.makeBody` is the stored closure on
             // `AnyMarkdownLinkRenderer` and already returns `AnyView` — no
             // explicit `.erasedToAnyView()` needed.

--- a/Sources/MarkdownView/Renderers/Node Representations/Links/MarkdownLinkRenderers.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Links/MarkdownLinkRenderers.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftUI
+
+class MarkdownLinkRenderers: @unchecked Sendable {
+    static let shared: MarkdownLinkRenderers = .init()
+    
+    private init() { }
+    
+    private(set) var renderers: [String: any MarkdownLinkRenderer] = [:]
+    
+    func addRenderer(
+        _ renderer: some MarkdownLinkRenderer,
+        forURLScheme urlScheme: String
+    ) {
+        renderers[urlScheme] = renderer
+    }
+    
+    static func named(_ name: String) -> (any MarkdownLinkRenderer)? {
+        if let renderer = MarkdownLinkRenderers.shared.renderers[name] {
+            return renderer
+        }
+        
+        let lowercaseName = name.lowercased()
+        return MarkdownLinkRenderers.shared
+            .renderers
+            .first(where: { $0.key.lowercased() == lowercaseName })?
+            .value
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
@@ -1,0 +1,91 @@
+//
+//  MarkdownLinkRenderer.swift
+//  MarkdownView
+//
+//  Orbit fork addition. Mirrors `MarkdownImageRenderer` so consumers can
+//  inject a custom view for inline links (e.g. favicon + URL hover tooltip).
+//
+
+import SwiftUI
+
+/// A type that renders inline markdown links.
+///
+/// Think of this type as a SwiftUI View wrapper.
+///
+/// Don't directly access view dependencies (e.g. `@Environment`), use a
+/// separate view instead.
+@preconcurrency
+@MainActor
+public protocol MarkdownLinkRenderer: Equatable, Sendable {
+    /// A type that represents the link.
+    associatedtype Body: View
+
+    /// Creates a view that represents the link.
+    /// - parameter configuration: The properties of a markdown link, including
+    ///   the destination `URL` and the already-styled default `label` view
+    ///   (text + inline images + inline code as the library would render it).
+    @preconcurrency
+    @MainActor
+    @ViewBuilder
+    func makeBody(configuration: Configuration) -> Body
+
+    /// The properties of a markdown link.
+    typealias Configuration = MarkdownLinkRendererConfiguration
+}
+
+/// The properties of a markdown link.
+///
+/// NOT `Sendable` — `label: AnyView` cannot be. Apple explicitly marks
+/// `AnyView: Sendable` as `@available(*, unavailable)` in
+/// `SwiftUICore.swiftinterface`. The image renderer's equivalent
+/// (`MarkdownImageRendererConfiguration`) is `Sendable` only because its
+/// fields are `URL + String?`. The renderer protocol above is
+/// `@preconcurrency @MainActor` so the configuration never crosses an actor
+/// boundary — `Sendable` isn't required.
+public struct MarkdownLinkRendererConfiguration {
+    /// The destination URL of the link.
+    public var url: URL
+    /// The already-styled default link contents (text, inline images,
+    /// inline code, etc.) as the library would render them without a
+    /// custom renderer. Wrap this in your custom view to preserve the
+    /// surrounding inline formatting.
+    public var label: AnyView
+}
+
+// MARK: - Type Erasure
+
+/// Type-erased `MarkdownLinkRenderer`.
+///
+/// `Equatable` so it can live in `MarkdownRendererConfiguration` and
+/// participate in renderer-cache invalidation: swapping the underlying
+/// renderer for a given scheme changes the equality of the surrounding
+/// `MarkdownRendererConfiguration`, which invalidates
+/// `CmarkFirstMarkdownViewRenderer`'s view cache.
+///
+/// `@unchecked Sendable`: the protocol's `Sendable` requirement makes
+/// `D: MarkdownLinkRenderer` automatically Sendable so the closure
+/// captures of `renderer: D` are legal. The `@unchecked` is for the
+/// `@MainActor` closure storage — Swift 6 strict mode flags
+/// `@MainActor (...) -> AnyView` stored properties as non-Sendable
+/// even though isolation guarantees they can only be called on
+/// MainActor. We've manually verified safety.
+public struct AnyMarkdownLinkRenderer: @unchecked Sendable, Equatable {
+    let makeBody: @MainActor (MarkdownLinkRendererConfiguration) -> AnyView
+    private let wrapped: Any
+    private let isEqualTo: (Any) -> Bool
+
+    public init<D: MarkdownLinkRenderer>(_ renderer: D) {
+        self.wrapped = renderer
+        self.makeBody = { config in
+            renderer.makeBody(configuration: config).erasedToAnyView()
+        }
+        self.isEqualTo = { other in
+            guard let other = other as? D else { return false }
+            return other == renderer
+        }
+    }
+
+    public static func == (lhs: AnyMarkdownLinkRenderer, rhs: AnyMarkdownLinkRenderer) -> Bool {
+        lhs.isEqualTo(rhs.wrapped)
+    }
+}

--- a/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Foundation
 
 /// A type that renders inline markdown links.
 ///
@@ -50,6 +51,12 @@ public struct MarkdownLinkRendererConfiguration {
     /// custom renderer. Wrap this in your custom view to preserve the
     /// surrounding inline formatting.
     public var label: AnyView
+    /// Inline emphasis inherited from ancestor nodes (e.g. a link inside
+    /// `**bold**` / `*italic*` / `~~strike~~`). The custom renderer's output is
+    /// a SwiftUI View that can't be re-styled by the ancestor, so the renderer
+    /// is responsible for reflecting this emphasis on its label — e.g. by
+    /// selecting a bold/italic font. Empty when the link isn't emphasized.
+    public var inlinePresentationIntent: InlinePresentationIntent = []
 }
 
 // MARK: - Type Erasure

--- a/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift
@@ -1,98 +1,29 @@
-//
-//  MarkdownLinkRenderer.swift
-//  MarkdownView
-//
-//  Orbit fork addition. Mirrors `MarkdownImageRenderer` so consumers can
-//  inject a custom view for inline links (e.g. favicon + URL hover tooltip).
-//
-
-import SwiftUI
 import Foundation
+import SwiftUI
 
-/// A type that renders inline markdown links.
-///
-/// Think of this type as a SwiftUI View wrapper.
-///
-/// Don't directly access view dependencies (e.g. `@Environment`), use a
-/// separate view instead.
 @preconcurrency
 @MainActor
-public protocol MarkdownLinkRenderer: Equatable, Sendable {
-    /// A type that represents the link.
+public protocol MarkdownLinkRenderer {
     associatedtype Body: View
 
-    /// Creates a view that represents the link.
-    /// - parameter configuration: The properties of a markdown link, including
-    ///   the destination `URL` and the already-styled default `label` view
-    ///   (text + inline images + inline code as the library would render it).
     @preconcurrency
     @MainActor
     @ViewBuilder
     func makeBody(configuration: Configuration) -> Body
 
-    /// The properties of a markdown link.
     typealias Configuration = MarkdownLinkRendererConfiguration
 }
 
-/// The properties of a markdown link.
-///
-/// NOT `Sendable` — `label: AnyView` cannot be. Apple explicitly marks
-/// `AnyView: Sendable` as `@available(*, unavailable)` in
-/// `SwiftUICore.swiftinterface`. The image renderer's equivalent
-/// (`MarkdownImageRendererConfiguration`) is `Sendable` only because its
-/// fields are `URL + String?`. The renderer protocol above is
-/// `@preconcurrency @MainActor` so the configuration never crosses an actor
-/// boundary — `Sendable` isn't required.
 public struct MarkdownLinkRendererConfiguration {
-    /// The destination URL of the link.
     public var url: URL
-    /// The already-styled default link contents (text, inline images,
-    /// inline code, etc.) as the library would render them without a
-    /// custom renderer. Wrap this in your custom view to preserve the
-    /// surrounding inline formatting.
-    public var label: AnyView
-    /// Inline emphasis inherited from ancestor nodes (e.g. a link inside
-    /// `**bold**` / `*italic*` / `~~strike~~`). The custom renderer's output is
-    /// a SwiftUI View that can't be re-styled by the ancestor, so the renderer
-    /// is responsible for reflecting this emphasis on its label — e.g. by
-    /// selecting a bold/italic font. Empty when the link isn't emphasized.
-    public var inlinePresentationIntent: InlinePresentationIntent = []
-}
+    private var renderedLabel: AnyView
 
-// MARK: - Type Erasure
-
-/// Type-erased `MarkdownLinkRenderer`.
-///
-/// `Equatable` so it can live in `MarkdownRendererConfiguration` and
-/// participate in renderer-cache invalidation: swapping the underlying
-/// renderer for a given scheme changes the equality of the surrounding
-/// `MarkdownRendererConfiguration`, which invalidates
-/// `CmarkFirstMarkdownViewRenderer`'s view cache.
-///
-/// `@unchecked Sendable`: the protocol's `Sendable` requirement makes
-/// `D: MarkdownLinkRenderer` automatically Sendable so the closure
-/// captures of `renderer: D` are legal. The `@unchecked` is for the
-/// `@MainActor` closure storage — Swift 6 strict mode flags
-/// `@MainActor (...) -> AnyView` stored properties as non-Sendable
-/// even though isolation guarantees they can only be called on
-/// MainActor. We've manually verified safety.
-public struct AnyMarkdownLinkRenderer: @unchecked Sendable, Equatable {
-    let makeBody: @MainActor (MarkdownLinkRendererConfiguration) -> AnyView
-    private let wrapped: Any
-    private let isEqualTo: (Any) -> Bool
-
-    public init<D: MarkdownLinkRenderer>(_ renderer: D) {
-        self.wrapped = renderer
-        self.makeBody = { config in
-            renderer.makeBody(configuration: config).erasedToAnyView()
-        }
-        self.isEqualTo = { other in
-            guard let other = other as? D else { return false }
-            return other == renderer
-        }
+    public var label: some View {
+        renderedLabel
     }
 
-    public static func == (lhs: AnyMarkdownLinkRenderer, rhs: AnyMarkdownLinkRenderer) -> Bool {
-        lhs.isEqualTo(rhs.wrapped)
+    init<Label: View>(url: URL, label: Label) {
+        self.url = url
+        self.renderedLabel = label.erasedToAnyView()
     }
 }


### PR DESCRIPTION
## Summary

Adds `markdownLinkRenderer`, mirroring the existing `markdownImageRenderer` pattern so consumers can inject a custom SwiftUI view for inline markdown links — e.g. favicon-prefixed links, hover tooltips, scheme-specific link UI.

## Motivation

`MarkdownImageRenderer` already lets consumers customize image rendering per URL scheme. Links have no equivalent — every consumer that wants custom link UI (favicons, tooltips, internal scheme handling) has to wrap or fork. This PR fills that symmetric gap with the same API shape.

## API

```swift
struct MyLinkRenderer: MarkdownLinkRenderer {
    func makeBody(configuration: Configuration) -> some View {
        HStack { faviconFor(configuration.url); configuration.label }
    }
}

MarkdownView(content)
    .markdownLinkRenderer(MyLinkRenderer(), forURLScheme: "https")
    // or, with the "*" wildcard, for ALL schemes:
    .markdownLinkRenderer(MyLinkRenderer())
```

`Configuration` exposes `url: URL`, `label: AnyView`, and `inlinePresentationIntent: InlinePresentationIntent` (the emphasis inherited from any enclosing `**bold**` / `*italic*` / `~~strikethrough~~` — empty when the link isn't emphasized). Dispatch is by URL scheme with `"*"` as a wildcard — extends the image-renderer's exact+lowercased-scheme match to also support a catch-all.

## Design notes

**Env-scoped storage, not a singleton.** Renderers live on `MarkdownRendererConfiguration.linkRenderers: [String: AnyMarkdownLinkRenderer]` and participate in `Equatable` so `CmarkFirstMarkdownViewRenderer`'s view cache invalidates correctly when a renderer instance changes. The modifier writes via `transformEnvironment`. No global state. Two callsites registering different renderers for the same scheme stay isolated to their respective subtrees.

(Note: the same global-singleton anti-pattern exists in `MarkdownImageRenders` upstream. Intentionally only fixing the link side here to minimize divergence — happy to follow up with a matching image-side fix in a separate PR if you'd like.)

**Sendable requirement on the protocol.** Mirrors SwiftUI's `AnyShape` pattern (`AnyShape` requires `S: Sendable` on init). Required for Swift 6 region-based isolation because `AnyMarkdownLinkRenderer`'s init captures the generic `renderer: D` into three stored closures.

> ⚠️ **Breaking change for consumers:** every type conforming to `MarkdownLinkRenderer` must now also conform to `Sendable`. Free for types with no stored properties — synthesis is implicit. New API, so the breakage only affects anyone tracking this branch pre-merge.

`Configuration` itself is intentionally NOT `Sendable` because `AnyView`'s `Sendable` conformance is `@available(*, unavailable)` per Apple. The protocol is `@preconcurrency @MainActor`, so the config never crosses an actor boundary in practice.

## Update: emphasized links (commit `b5bbdd0`)

A link nested inside `**bold**` / `*italic*` / `~~strikethrough~~` was **silently dropped**. `visitStrong` / `visitEmphasis` / `visitStrikethrough` composited their children into a single `AttributedString` and skipped any child whose `MarkdownNodeView` is view-backed (`asAttributedString == nil`) — which is exactly what a custom `MarkdownLinkRenderer` produces. So an emphasized custom-rendered link disappeared entirely.

This commit:

- Makes those three visitors **keep view-backed children** (laid out alongside the text via `MarkdownNodeView`'s text+view compositor) instead of dropping them. Pure-text emphasis is unchanged — a single text child collapses back to the same `AttributedString`, so there's no behavioral or layout difference for ordinary bold/italic text.
- **Threads the inherited inline emphasis down the visit** and surfaces it on `MarkdownLinkRendererConfiguration.inlinePresentationIntent`, so a custom renderer can reflect it on its label. This is deliberately the *renderer's* job, not the library's: an `inlinePresentationIntent` attribute (or `.bold()`) on the label doesn't reliably render through a custom renderer's view, and a custom font's bold face must be selected explicitly — only the renderer knows its own font, so the library just hands it the intent.

## Files

| File | Change |
|------|--------|
| `Modifiers/MarkdownLinkRendererModifier.swift` | new — public `View.markdownLinkRenderer(_:forURLScheme:)` |
| `Renderers/Node Representations/Links/Protocol/MarkdownLinkRenderer.swift` | new — protocol + `Configuration` (incl. `inlinePresentationIntent`) + `AnyMarkdownLinkRenderer` |
| `Configurations/MarkdownRendererConfiguration.swift` | adds `linkRenderers` field, contributes to `Equatable` |
| `Renderers/Cmark/CmarkNodeVisitor.swift` | `visitLink` dispatches to custom renderer if registered for the URL scheme (or `"*"`) and passes inherited emphasis; default branch adds `.help(url)` for the native macOS hover tooltip; `visitStrong`/`visitEmphasis`/`visitStrikethrough` preserve view-backed children instead of dropping them |

## Verification

- [x] `swift build` — Build complete!
- [x] Used in production by an external macOS app (`@MainActor` SwiftUI consumer) — favicon + URL hover tooltip on inline markdown links in an AI chat surface, including emphasized links rendering bold via the renderer. Renders thousands of links per session, no observed cache thrash or render glitches.

## MarkdownView 3 / #132

I see #132 ("Introducing MarkdownView 3") is in draft. If v3 plans to ship a link-renderer hook with a different architecture, happy to defer this — just let me know. Otherwise this should be useful for everyone on the current 2.x line.
