### PR TITLE
Fix stale Markdown text render state during streaming updates

### DIFF
--- a/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
@@ -22,12 +22,19 @@ struct _MarkdownText: View {
         Text(Self.visibleText(input: text, rendered: renderedState))
             .task(id: text) {
                 let renderedState = Self.renderedState(for: text)
+                // Streaming updates can start a new render before an older render finishes.
+                // Avoid committing work SwiftUI already cancelled for a superseded input.
                 guard !Task.isCancelled else { return }
                 self.renderedState = renderedState
             }
     }
 
     static func visibleText(input: AttributedString, rendered: RenderedState?) -> AttributedString {
+        // `renderedState` is asynchronous cache state. During streaming, an older
+        // partial input can finish after the latest input and briefly live in
+        // `@State`. Only use the cached output when it was produced from the
+        // exact input currently being displayed; otherwise fall back to `input`
+        // so the visible text cannot regress while the next render catches up.
         guard let rendered, rendered.input == input else {
             return input
         }
@@ -62,7 +69,10 @@ struct _MarkdownText: View {
     }
 
     struct RenderedState {
+        /// The source markdown text that produced `output`.
         var input: AttributedString
+
+        /// The same content after asynchronous HTML runs have been converted.
         var output: AttributedString
     }
 }

--- a/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
@@ -20,8 +20,8 @@ struct _MarkdownText: View {
 
     var body: some View {
         Group {
-            if let attributedString = Self.renderedOutput(input: text, rendered: attributedString) {
-                Text(attributedString)
+            if let attributedString {
+                Text(Self.visibleText(input: text, rendered: attributedString))
             } else {
                 Text(text)
             }
@@ -51,17 +51,13 @@ struct _MarkdownText: View {
         }
     }
 
-    static func visibleText(input: AttributedString, rendered: RenderedState?) -> AttributedString {
+    static func visibleText(input: AttributedString, rendered: RenderedState) -> AttributedString {
         // `renderedState` is asynchronous cache state. During streaming, an older
         // partial input can finish after the latest input and briefly live in
         // `@State`. Only use the cached output when it was produced from the
         // exact input currently being displayed; otherwise fall back to `input`
         // so the visible text cannot regress while the next render catches up.
-        renderedOutput(input: input, rendered: rendered) ?? input
-    }
-
-    static func renderedOutput(input: AttributedString, rendered: RenderedState?) -> AttributedString? {
-        guard let rendered, rendered.input == input else { return nil }
+        guard rendered.input == input else { return input }
         return rendered.output
     }
 

--- a/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
@@ -12,21 +12,43 @@ import SwiftUI
 /// Convert HTML into  `AttributedString` asynchronously to avoid `AttributeGraph` crash.
 struct _MarkdownText: View {
     var text: AttributedString
-    @State private var renderedState: RenderedState?
+    @State private var attributedString: RenderedState?
     
     init(_ text: AttributedString) {
         self.text = text
     }
 
     var body: some View {
-        Text(Self.visibleText(input: text, rendered: renderedState))
-            .task(id: text) {
-                let renderedState = Self.renderedState(for: text)
-                // Streaming updates can start a new render before an older render finishes.
-                // Avoid committing work SwiftUI already cancelled for a superseded input.
-                guard !Task.isCancelled else { return }
-                self.renderedState = renderedState
+        Group {
+            if let attributedString = Self.renderedOutput(input: text, rendered: attributedString) {
+                Text(attributedString)
+            } else {
+                Text(text)
             }
+        }
+        .task(id: text) {
+            var attributedString = text
+            for run in text.runs.reversed() where (run.isHTML ?? false) {
+                let range = run.range
+
+                if let htmlAttrString = try? AttributedString(
+                    NSAttributedString(
+                        data: Data(String(text.characters[range]).utf8),
+                        options: [
+                            .documentType: NSAttributedString.DocumentType.html
+                        ],
+                        documentAttributes: nil
+                    )
+                ) {
+                    attributedString.replaceSubrange(range, with: htmlAttrString)
+                }
+            }
+
+            // Streaming updates can start a new render before an older render finishes.
+            // Avoid committing work SwiftUI already cancelled for a superseded input.
+            guard !Task.isCancelled else { return }
+            self.attributedString = RenderedState(input: text, output: attributedString)
+        }
     }
 
     static func visibleText(input: AttributedString, rendered: RenderedState?) -> AttributedString {
@@ -35,37 +57,12 @@ struct _MarkdownText: View {
         // `@State`. Only use the cached output when it was produced from the
         // exact input currently being displayed; otherwise fall back to `input`
         // so the visible text cannot regress while the next render catches up.
-        guard let rendered, rendered.input == input else {
-            return input
-        }
+        renderedOutput(input: input, rendered: rendered) ?? input
+    }
+
+    static func renderedOutput(input: AttributedString, rendered: RenderedState?) -> AttributedString? {
+        guard let rendered, rendered.input == input else { return nil }
         return rendered.output
-    }
-
-    static func renderedState(for text: AttributedString) -> RenderedState {
-        RenderedState(
-            input: text,
-            output: renderedText(from: text)
-        )
-    }
-
-    static func renderedText(from text: AttributedString) -> AttributedString {
-        var attributedString = text
-        for run in text.runs.reversed() where (run.isHTML ?? false) {
-            let range = run.range
-
-            if let htmlAttrString = try? AttributedString(
-                NSAttributedString(
-                    data: Data(String(text.characters[range]).utf8),
-                    options: [
-                        .documentType: NSAttributedString.DocumentType.html
-                    ],
-                    documentAttributes: nil
-                )
-            ) {
-                attributedString.replaceSubrange(range, with: htmlAttrString)
-            }
-        }
-        return attributedString
     }
 
     struct RenderedState {

--- a/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
+++ b/Sources/MarkdownView/Renderers/Node Representations/_MarkdownText.swift
@@ -12,38 +12,57 @@ import SwiftUI
 /// Convert HTML into  `AttributedString` asynchronously to avoid `AttributeGraph` crash.
 struct _MarkdownText: View {
     var text: AttributedString
-    @State private var attributedString: AttributedString?
+    @State private var renderedState: RenderedState?
     
     init(_ text: AttributedString) {
         self.text = text
     }
-    
+
     var body: some View {
-        Group {
-            if let attributedString {
-                Text(attributedString)
-            } else {
-                Text(text)
+        Text(Self.visibleText(input: text, rendered: renderedState))
+            .task(id: text) {
+                let renderedState = Self.renderedState(for: text)
+                guard !Task.isCancelled else { return }
+                self.renderedState = renderedState
+            }
+    }
+
+    static func visibleText(input: AttributedString, rendered: RenderedState?) -> AttributedString {
+        guard let rendered, rendered.input == input else {
+            return input
+        }
+        return rendered.output
+    }
+
+    static func renderedState(for text: AttributedString) -> RenderedState {
+        RenderedState(
+            input: text,
+            output: renderedText(from: text)
+        )
+    }
+
+    static func renderedText(from text: AttributedString) -> AttributedString {
+        var attributedString = text
+        for run in text.runs.reversed() where (run.isHTML ?? false) {
+            let range = run.range
+
+            if let htmlAttrString = try? AttributedString(
+                NSAttributedString(
+                    data: Data(String(text.characters[range]).utf8),
+                    options: [
+                        .documentType: NSAttributedString.DocumentType.html
+                    ],
+                    documentAttributes: nil
+                )
+            ) {
+                attributedString.replaceSubrange(range, with: htmlAttrString)
             }
         }
-        .task(id: text) {
-            var attributedString = text
-            for run in text.runs.reversed() where (run.isHTML ?? false) {
-                let range = run.range
-                
-                if let htmlAttrString = try? AttributedString(
-                    NSAttributedString(
-                        data: Data(String(text.characters[range]).utf8),
-                        options: [
-                            .documentType: NSAttributedString.DocumentType.html
-                        ],
-                        documentAttributes: nil
-                    )
-                ) {
-                    attributedString.replaceSubrange(range, with: htmlAttrString)
-                }
-            }
-            self.attributedString = attributedString
-        }
+        return attributedString
+    }
+
+    struct RenderedState {
+        var input: AttributedString
+        var output: AttributedString
     }
 }

--- a/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
+++ b/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
@@ -10,10 +10,16 @@ import Testing
 
 @testable import MarkdownView
 
+/// Regression coverage for streamed Markdown updates where the source text is
+/// already complete, but `_MarkdownText` can still show a stale rendered result
+/// from an older partial update.
 @Suite("Markdown Text State")
 struct MarkdownTextStateTests {
     @Test
     func markdownContentCacheKeyChangesWithInputText() {
+        // Proves the parser/cache key changes with the raw Markdown. If this
+        // failed, stale output could come from reusing a rendered document for
+        // different source text instead of from `_MarkdownText` state.
         let partialContent = MarkdownContent(raw: .plainText(Self.partialBugMarkdown))
         let finalContent = MarkdownContent(raw: .plainText(Self.bugMarkdown))
 
@@ -25,6 +31,9 @@ struct MarkdownTextStateTests {
     @Test
     @MainActor
     func renderedTextKeepsLatestInputCharacters() {
+        // Proves the HTML conversion stage does not truncate the final message.
+        // The stale visual text bug happens after this conversion, when the
+        // converted result is stored and selected for display.
         let renderedText = _MarkdownText.renderedText(from: AttributedString(Self.bugMarkdown))
 
         #expect(String(renderedText.characters) == Self.bugMarkdown)
@@ -33,6 +42,9 @@ struct MarkdownTextStateTests {
     @Test
     @MainActor
     func olderRenderTaskCannotOverwriteNewerRenderedState() {
+        // Simulates the race from streaming updates: the final input renders
+        // first, then an older partial render commits later. The visible text
+        // must stay on the latest input because rendered state is source-bound.
         let latestInput = AttributedString(Self.bugMarkdown)
         var renderedState: _MarkdownText.RenderedState?
 
@@ -50,6 +62,9 @@ struct MarkdownTextStateTests {
     @Test
     @MainActor
     func visibleTextUsesLatestInputWhenRenderedStateBelongsToPreviousInput() {
+        // Verifies the display decision directly. A cached rendered state for a
+        // previous partial input must be ignored when SwiftUI asks the same view
+        // identity to display newer text.
         let renderedText = _MarkdownText.renderedState(for: AttributedString(Self.partialBugMarkdown))
 
         let visibleText = _MarkdownText.visibleText(
@@ -63,6 +78,9 @@ struct MarkdownTextStateTests {
     @Test
     @MainActor
     func rebuildingViewIdentityShowsLatestInputText() {
+        // Documents why forcing a new SwiftUI identity with `.id(...)` masks the
+        // bug: the state starts empty, so `_MarkdownText` falls back to the
+        // current input before any async render finishes.
         let rebuiltVisibleText = _MarkdownText.visibleText(
             input: AttributedString(Self.bugMarkdown),
             rendered: nil
@@ -72,6 +90,8 @@ struct MarkdownTextStateTests {
 }
 
 private extension MarkdownTextStateTests {
+    // A realistic partial stream chunk captured from the reported failure. The
+    // missing tail starts after the ticket example.
     static let partialBugMarkdown = """
     ## 翻譯與理解
 
@@ -114,6 +134,8 @@ private extension MarkdownTextStateTests {
       - チケットが欲しい人いますか？（ちけっと が ほしい ひと いますか）：有想要票的人嗎？
     """
 
+    // The final stream content. Tests compare against this value to ensure the
+    // UI-facing text never regresses to `partialBugMarkdown`.
     static let bugMarkdown = partialBugMarkdown + """
 
       - これが欲しい人は手を挙げてください（これ が ほしい ひと は て を あげて ください）：想要這個的人請舉手

--- a/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
+++ b/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
@@ -1,0 +1,129 @@
+//
+//  MarkdownTextStateTests.swift
+//  MarkdownView
+//
+//  Created by Codex on 2026/6/15.
+//
+
+import Foundation
+import Testing
+
+@testable import MarkdownView
+
+@Suite("Markdown Text State")
+struct MarkdownTextStateTests {
+    @Test
+    func markdownContentCacheKeyChangesWithInputText() {
+        let partialContent = MarkdownContent(raw: .plainText(Self.partialBugMarkdown))
+        let finalContent = MarkdownContent(raw: .plainText(Self.bugMarkdown))
+
+        #expect(partialContent != finalContent)
+        #expect(partialContent.raw.text == Self.partialBugMarkdown)
+        #expect(finalContent.raw.text == Self.bugMarkdown)
+    }
+
+    @Test
+    @MainActor
+    func renderedTextKeepsLatestInputCharacters() {
+        let renderedText = _MarkdownText.renderedText(from: AttributedString(Self.bugMarkdown))
+
+        #expect(String(renderedText.characters) == Self.bugMarkdown)
+    }
+
+    @Test
+    @MainActor
+    func olderRenderTaskCannotOverwriteNewerRenderedState() {
+        let latestInput = AttributedString(Self.bugMarkdown)
+        var renderedState: _MarkdownText.RenderedState?
+
+        renderedState = _MarkdownText.renderedState(for: latestInput)
+        renderedState = _MarkdownText.renderedState(for: AttributedString(Self.partialBugMarkdown))
+
+        let visibleText = _MarkdownText.visibleText(
+            input: latestInput,
+            rendered: renderedState
+        )
+
+        #expect(String(visibleText.characters) == Self.bugMarkdown)
+    }
+
+    @Test
+    @MainActor
+    func visibleTextUsesLatestInputWhenRenderedStateBelongsToPreviousInput() {
+        let renderedText = _MarkdownText.renderedState(for: AttributedString(Self.partialBugMarkdown))
+
+        let visibleText = _MarkdownText.visibleText(
+            input: AttributedString(Self.bugMarkdown),
+            rendered: renderedText
+        )
+
+        #expect(String(visibleText.characters) == Self.bugMarkdown)
+    }
+
+    @Test
+    @MainActor
+    func rebuildingViewIdentityShowsLatestInputText() {
+        let rebuiltVisibleText = _MarkdownText.visibleText(
+            input: AttributedString(Self.bugMarkdown),
+            rendered: nil
+        )
+        #expect(String(rebuiltVisibleText.characters) == Self.bugMarkdown)
+    }
+}
+
+private extension MarkdownTextStateTests {
+    static let partialBugMarkdown = """
+    ## 翻譯與理解
+
+    這句日文「Root化済み個体、63000円+送料とかで欲しい人いますか？」的意思是：
+
+    「有沒有人想要（這台）已經Root過的裝置，價格是63000日圓加運費之類的？」
+
+    - **Root化済み個体**：已經Root過的裝置（個體）
+    - **63000円+送料とかで**：以63000日圓加運費之類的價格
+    - **欲しい人いますか？**：有想要的人嗎？
+
+    ## 語法解析
+
+    ### 1. ～済み（すみ）
+
+    - **用法**：「～済み」表示某件事情已經完成。常見於動詞的連用形後面。
+    - **例句**：
+      - 予約済み（よやくずみ）：已預約
+      - 支払い済み（しはらいずみ）：已付款
+      - Root化済み（るーとかずみ）：已Root化
+
+    ### 2. 個体（こたい）
+
+    - **用法**：在這裡指「個體」，常用於動物、裝置等單一個體。
+    - **例句**：
+      - この個体（この こたい）：這個個體
+      - 新しい個体（あたらしい こたい）：新的個體
+
+    ### 3. 63000円+送料とかで
+
+    - **用法**：「とか」在這裡有「之類的」的意思，表示價格可能有彈性或只是舉例。
+    - **例句**：
+      - 1000円とかで売っている（せんえん とか で うっている）：用1000日圓之類的價格在賣
+      - 友達とかと行きます（ともだち とか と いきます）：會和朋友之類的人一起去
+
+    ### 4. 欲しい人いますか？
+
+    - **用法**：「欲しい（ほしい）」是「想要」的意思，「人」指人，「いますか」是「有嗎」的意思。
+    - **例句**：
+      - チケットが欲しい人いますか？（ちけっと が ほしい ひと いますか）：有想要票的人嗎？
+    """
+
+    static let bugMarkdown = partialBugMarkdown + """
+
+      - これが欲しい人は手を挙げてください（これ が ほしい ひと は て を あげて ください）：想要這個的人請舉手
+
+    ## 其他值得注意的知識點
+
+    - **Root化**：這是來自英文「Root」，指Android裝置取得最高權限。
+    - **とか**：在口語中常用來表示舉例、列舉或語氣上的緩和，讓語句聽起來不那麼生硬。
+    - **で**：這裡是表示「以～（價格）」的意思。
+
+    希望這樣的解析能幫助你更好理解這句日文的用法！
+    """
+}

--- a/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
+++ b/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
@@ -30,11 +30,14 @@ struct MarkdownTextStateTests {
 
     @Test
     @MainActor
-    func renderedTextKeepsLatestInputCharacters() {
-        // Proves the HTML conversion stage does not truncate the final message.
-        // The stale visual text bug happens after this conversion, when the
-        // converted result is stored and selected for display.
-        let renderedText = _MarkdownText.renderedText(from: AttributedString(Self.bugMarkdown))
+    func renderedStateUsesOutputForMatchingInput() {
+        // Proves the display helper still uses the async rendered output when
+        // that output belongs to the exact input SwiftUI is asking it to show.
+        let input = AttributedString(Self.bugMarkdown)
+        let renderedText = _MarkdownText.visibleText(
+            input: input,
+            rendered: _MarkdownText.RenderedState(input: input, output: input)
+        )
 
         #expect(String(renderedText.characters) == Self.bugMarkdown)
     }
@@ -48,8 +51,11 @@ struct MarkdownTextStateTests {
         let latestInput = AttributedString(Self.bugMarkdown)
         var renderedState: _MarkdownText.RenderedState?
 
-        renderedState = _MarkdownText.renderedState(for: latestInput)
-        renderedState = _MarkdownText.renderedState(for: AttributedString(Self.partialBugMarkdown))
+        renderedState = _MarkdownText.RenderedState(input: latestInput, output: latestInput)
+        renderedState = _MarkdownText.RenderedState(
+            input: AttributedString(Self.partialBugMarkdown),
+            output: AttributedString(Self.partialBugMarkdown)
+        )
 
         let visibleText = _MarkdownText.visibleText(
             input: latestInput,
@@ -65,7 +71,10 @@ struct MarkdownTextStateTests {
         // Verifies the display decision directly. A cached rendered state for a
         // previous partial input must be ignored when SwiftUI asks the same view
         // identity to display newer text.
-        let renderedText = _MarkdownText.renderedState(for: AttributedString(Self.partialBugMarkdown))
+        let renderedText = _MarkdownText.RenderedState(
+            input: AttributedString(Self.partialBugMarkdown),
+            output: AttributedString(Self.partialBugMarkdown)
+        )
 
         let visibleText = _MarkdownText.visibleText(
             input: AttributedString(Self.bugMarkdown),

--- a/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
+++ b/Sources/MarkdownViewTests/MarkdownTextStateTests.swift
@@ -10,97 +10,44 @@ import Testing
 
 @testable import MarkdownView
 
-/// Regression coverage for streamed Markdown updates where the source text is
-/// already complete, but `_MarkdownText` can still show a stale rendered result
-/// from an older partial update.
+/// Regression coverage for streamed Markdown updates where `_MarkdownText`
+/// may hold rendered state from an older partial input.
 @Suite("Markdown Text State")
 struct MarkdownTextStateTests {
     @Test
-    func markdownContentCacheKeyChangesWithInputText() {
-        // Proves the parser/cache key changes with the raw Markdown. If this
-        // failed, stale output could come from reusing a rendered document for
-        // different source text instead of from `_MarkdownText` state.
-        let partialContent = MarkdownContent(raw: .plainText(Self.partialBugMarkdown))
-        let finalContent = MarkdownContent(raw: .plainText(Self.bugMarkdown))
-
-        #expect(partialContent != finalContent)
-        #expect(partialContent.raw.text == Self.partialBugMarkdown)
-        #expect(finalContent.raw.text == Self.bugMarkdown)
-    }
-
-    @Test
     @MainActor
-    func renderedStateUsesOutputForMatchingInput() {
-        // Proves the display helper still uses the async rendered output when
-        // that output belongs to the exact input SwiftUI is asking it to show.
-        let input = AttributedString(Self.bugMarkdown)
-        let renderedText = _MarkdownText.visibleText(
+    func visibleTextUsesRenderedOutputForMatchingInput() {
+        // Normal path: when rendered state belongs to the current input, display
+        // the rendered output rather than falling back to the raw input.
+        let input = AttributedString("raw <strong>markdown</strong>")
+        let output = AttributedString("raw markdown")
+
+        let visibleText = _MarkdownText.visibleText(
             input: input,
-            rendered: _MarkdownText.RenderedState(input: input, output: input)
+            rendered: _MarkdownText.RenderedState(input: input, output: output)
         )
 
-        #expect(String(renderedText.characters) == Self.bugMarkdown)
+        #expect(visibleText == output)
     }
 
     @Test
     @MainActor
-    func olderRenderTaskCannotOverwriteNewerRenderedState() {
-        // Simulates the race from streaming updates: the final input renders
-        // first, then an older partial render commits later. The visible text
-        // must stay on the latest input because rendered state is source-bound.
-        let latestInput = AttributedString(Self.bugMarkdown)
-        var renderedState: _MarkdownText.RenderedState?
-
-        renderedState = _MarkdownText.RenderedState(input: latestInput, output: latestInput)
-        renderedState = _MarkdownText.RenderedState(
-            input: AttributedString(Self.partialBugMarkdown),
-            output: AttributedString(Self.partialBugMarkdown)
-        )
-
+    func visibleTextFallsBackToLatestInputForStaleRenderedState() {
+        // Streaming can leave a rendered result from an older partial input in
+        // state. That stale output must not replace the latest input.
         let visibleText = _MarkdownText.visibleText(
-            input: latestInput,
-            rendered: renderedState
+            input: AttributedString(Self.bugMarkdown),
+            rendered: _MarkdownText.RenderedState(
+                input: AttributedString(Self.partialBugMarkdown),
+                output: AttributedString(Self.partialBugMarkdown)
+            )
         )
 
         #expect(String(visibleText.characters) == Self.bugMarkdown)
-    }
-
-    @Test
-    @MainActor
-    func visibleTextUsesLatestInputWhenRenderedStateBelongsToPreviousInput() {
-        // Verifies the display decision directly. A cached rendered state for a
-        // previous partial input must be ignored when SwiftUI asks the same view
-        // identity to display newer text.
-        let renderedText = _MarkdownText.RenderedState(
-            input: AttributedString(Self.partialBugMarkdown),
-            output: AttributedString(Self.partialBugMarkdown)
-        )
-
-        let visibleText = _MarkdownText.visibleText(
-            input: AttributedString(Self.bugMarkdown),
-            rendered: renderedText
-        )
-
-        #expect(String(visibleText.characters) == Self.bugMarkdown)
-    }
-
-    @Test
-    @MainActor
-    func rebuildingViewIdentityShowsLatestInputText() {
-        // Documents why forcing a new SwiftUI identity with `.id(...)` masks the
-        // bug: the state starts empty, so `_MarkdownText` falls back to the
-        // current input before any async render finishes.
-        let rebuiltVisibleText = _MarkdownText.visibleText(
-            input: AttributedString(Self.bugMarkdown),
-            rendered: nil
-        )
-        #expect(String(rebuiltVisibleText.characters) == Self.bugMarkdown)
     }
 }
 
 private extension MarkdownTextStateTests {
-    // A realistic partial stream chunk captured from the reported failure. The
-    // missing tail starts after the ticket example.
     static let partialBugMarkdown = """
     ## 翻譯與理解
 
@@ -143,8 +90,6 @@ private extension MarkdownTextStateTests {
       - チケットが欲しい人いますか？（ちけっと が ほしい ひと いますか）：有想要票的人嗎？
     """
 
-    // The final stream content. Tests compare against this value to ensure the
-    // UI-facing text never regresses to `partialBugMarkdown`.
     static let bugMarkdown = partialBugMarkdown + """
 
       - これが欲しい人は手を挙げてください（これ が ほしい ひと は て を あげて ください）：想要這個的人請舉手


### PR DESCRIPTION
## Summary

This PR fixes a stale text rendering issue in `_MarkdownText` that can appear when Markdown content is updated repeatedly, such as during streamed text generation.

In the affected case, the source Markdown string has already been updated to the final complete content, but the visible SwiftUI `Text` can still show an older partial render. This makes the UI appear truncated even though code reading the source content still gets the complete text.

## Root Cause

`_MarkdownText` converts HTML runs asynchronously inside `.task(id: text)` and stores the converted `AttributedString` in `@State`.

Before this change, the state only stored the rendered output. During streaming updates, an older render task can complete after a newer input has already been provided. When that happens, the older partial render may remain in `@State` and be displayed for a newer complete `text` value.

In other words, the rendered cache was not tied to the source input that produced it.

## Fix

This PR changes the cached render state to store both the source input and the rendered output.

The visible text now uses cached rendered output only when it was produced from the exact same input currently being displayed. If the cached render belongs to an older partial input, `_MarkdownText` falls back to the latest input.

The task also checks `Task.isCancelled` before committing the rendered result, so work cancelled for a superseded input is not written back into state.

## Tests

Added focused regression coverage for `_MarkdownText` state selection:

- cached rendered output is used when it belongs to the current input
- stale rendered output from an older partial input is ignored, and the latest input is displayed instead