### PR TITLE
Fix Xcode 27 Document ambiguity

### DIFF
--- a/Sources/MarkdownView/MarkdownTableOfContentReader.swift
+++ b/Sources/MarkdownView/MarkdownTableOfContentReader.swift
@@ -49,7 +49,7 @@ public struct MarkdownTableOfContentReader<Content: View>: View, @MainActor Equa
         _ string: String,
         @ViewBuilder content: @escaping ([Markdown.Heading]) -> Content
     ) {
-        self.init(Document(parsing: string), content: content)
+        self.init(Markdown.Document(parsing: string), content: content)
     }
     
     private var headings: [Heading] {

--- a/Sources/MarkdownView/Math/Preprocessing/MathParsableRangesResolver.swift
+++ b/Sources/MarkdownView/Math/Preprocessing/MathParsableRangesResolver.swift
@@ -25,7 +25,7 @@ struct MathParsableRangesResolver: MarkupWalker {
         }
     }
 
-    mutating func visitDocument(_ document: Document) {
+    mutating func visitDocument(_ document: Markdown.Document) {
         for child in document.children {
             if let range = child.range {
                 resolvableIncludedRanges.append(range)

--- a/Sources/MarkdownView/Rendering/MarkdownText/MarkdownTextConverter.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownText/MarkdownTextConverter.swift
@@ -77,7 +77,7 @@ struct MarkdownTextConverter: @MainActor MarkupVisitor {
         )
     }
 
-    func visitDocument(_ document: Document) -> TextContent {
+    func visitDocument(_ document: Markdown.Document) -> TextContent {
         return render(
             MarkdownTextSemanticBuilder(configuration: configuration)
                 .makeNodes(for: document)

--- a/Sources/MarkdownView/Rendering/MarkdownText/Semantics/MarkdownTextSemanticBuilder.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownText/Semantics/MarkdownTextSemanticBuilder.swift
@@ -15,7 +15,7 @@ struct MarkdownTextSemanticBuilder: MarkupVisitor {
     }
 
     func makeNodes(for markup: any Markup) -> [MarkdownTextSemanticNode] {
-        if let document = markup as? Document {
+        if let document = markup as? Markdown.Document {
             return makeNodes(descendingInto: document)
         }
 

--- a/Sources/MarkdownView/Rendering/MarkdownView/MarkdownViewRenderer.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownView/MarkdownViewRenderer.swift
@@ -41,7 +41,7 @@ struct MarkdownViewRenderer: @preconcurrency MarkupVisitor {
             .environment(\.markdownElementRenderers, elementRenderers)
     }
 
-    func visitDocument(_ document: Document) -> MarkdownNodeView {
+    func visitDocument(_ document: Markdown.Document) -> MarkdownNodeView {
         var renderer = self
         let nodeViews = document.children.map {
             renderer.visit($0)


### PR DESCRIPTION
## Summary

Qualify references to swift-markdown's document type as `Markdown.Document`.

## Why

Xcode 27 introduces a new SwiftUI `Document` protocol for the document-based app APIs (`ReadableDocument` / `WritableDocument`). Files in MarkdownView that import both `SwiftUI` and `Markdown` can therefore resolve a bare `Document` reference to either `SwiftUI.Document` or `Markdown.Document`, which makes the type lookup ambiguous.

This keeps the intended swift-markdown AST type explicit and remains source-compatible with earlier SDKs.

## Validation

- Xcode 26.3 (`/Applications/Xcode-26.3.0.app`): `swift build` passed
- Xcode 26.3 (`/Applications/Xcode-26.3.0.app`): `swift test` passed, 68 tests
- Xcode 27.0 beta 2 (`/Applications/Xcode-27.0.0-Beta.2.app`): `swift build` passed
- Xcode 27.0 beta 2 (`/Applications/Xcode-27.0.0-Beta.2.app`): `swift test` passed, 68 tests
