### PR TITLE
Fix display math rendering

### DIFF
--- a/Sources/MarkdownView/Math/MarkdownMathPreprocessor.swift
+++ b/Sources/MarkdownView/Math/MarkdownMathPreprocessor.swift
@@ -80,6 +80,11 @@ extension MarkdownMathPreprocessor {
         let identifier: UUID
     }
 
+    struct PlaceholderSegment: Sendable, Hashable {
+        let match: PlaceholderMatch
+        let range: Range<String.Index>
+    }
+
     struct Replacement: Sendable, Hashable {
         let sourceRange: Range<Int>
         let processedRange: Range<Int>
@@ -180,6 +185,33 @@ extension MarkdownMathPreprocessor {
         }
 
         return PlaceholderMatch(kind: kind, identifier: identifier)
+    }
+
+    static func placeholderSegments(in text: String) -> [PlaceholderSegment] {
+        var segments: [PlaceholderSegment] = []
+        var searchRange = text.startIndex..<text.endIndex
+
+        while let prefixRange = text.range(of: placeholderPrefix, range: searchRange) {
+            let payloadRange = prefixRange.upperBound..<text.endIndex
+            guard let suffixRange = text.range(of: placeholderSuffix, range: payloadRange) else {
+                break
+            }
+
+            let placeholderRange = prefixRange.lowerBound..<suffixRange.upperBound
+            if let placeholderMatch = placeholderMatch(in: String(text[placeholderRange])) {
+                segments.append(
+                    PlaceholderSegment(
+                        match: placeholderMatch,
+                        range: placeholderRange
+                    )
+                )
+                searchRange = placeholderRange.upperBound..<text.endIndex
+            } else {
+                searchRange = prefixRange.upperBound..<text.endIndex
+            }
+        }
+
+        return segments
     }
 
     static func displayPlaceholderIdentifier(in text: String) -> UUID? {

--- a/Sources/MarkdownView/Rendering/MarkdownText/MarkdownTextConverter.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownText/MarkdownTextConverter.swift
@@ -146,7 +146,7 @@ struct MarkdownTextConverter: @MainActor MarkupVisitor {
             return MarkdownTextEmbeddingViewFactory.makeTextContent(
                 id: MarkdownTextInlineViewIdentifier(
                     markup: text,
-                    role: .blockAttachment
+                    role: .math(kind: .display, occurrence: 0)
                 ),
                 replacement: nil,
                 componentSpacing: configuration.componentSpacing,
@@ -156,11 +156,10 @@ struct MarkdownTextConverter: @MainActor MarkupVisitor {
                     .id(mathIdentifier)
             }
         }
-        if mathContext != nil,
-           let inlineMathStorage = mathContext?.inlineMathStorage {
-            return inlineMathTextContent(
+        if let mathContext {
+            return mathPlaceholderTextContent(
                 text: plainText,
-                inlineMathStorage: inlineMathStorage,
+                mathContext: mathContext,
                 sourceMarkup: text
             )
         }

--- a/Sources/MarkdownView/Rendering/MarkdownText/Rendering/MarkdownTextConverter+InlineMath.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownText/Rendering/MarkdownTextConverter+InlineMath.swift
@@ -6,39 +6,71 @@ import SwiftUI
 import Markdown
 
 extension MarkdownTextConverter {
-    func inlineMathTextContent(
+    func mathPlaceholderTextContent(
         text: String,
-        inlineMathStorage: [UUID: String],
+        mathContext: MarkdownMathContext,
         sourceMarkup: Markdown.Text
     ) -> TextContent {
         var textContent = TextContent([])
         var searchRange = text.startIndex..<text.endIndex
         var inlineMathOccurrence = 0
+        var displayMathOccurrence = 0
 
-        while let placeholderMatch = firstInlineMathPlaceholderMatch(
-            in: text,
-            range: searchRange,
-            inlineMathStorage: inlineMathStorage
-        ) {
-            if searchRange.lowerBound < placeholderMatch.range.lowerBound {
+        for placeholderSegment in MarkdownMathPreprocessor.placeholderSegments(in: text) {
+            guard placeholderSegment.range.lowerBound >= searchRange.lowerBound else {
+                continue
+            }
+
+            if searchRange.lowerBound < placeholderSegment.range.lowerBound {
                 textContent += TextContent(
-                    .string(String(text[searchRange.lowerBound..<placeholderMatch.range.lowerBound]))
+                    .string(String(text[searchRange.lowerBound..<placeholderSegment.range.lowerBound]))
                 )
             }
 
-            textContent += TextContent {
-                InlineView(
+            switch placeholderSegment.match.kind {
+            case .inline:
+                guard let latexText = mathContext.inlineMathStorage[placeholderSegment.match.identifier] else {
+                    textContent += TextContent(.string(String(text[placeholderSegment.range])))
+                    searchRange = placeholderSegment.range.upperBound..<text.endIndex
+                    continue
+                }
+
+                textContent += TextContent {
+                    InlineView(
+                        id: MarkdownTextInlineViewIdentifier(
+                            markup: sourceMarkup,
+                            role: .math(kind: .inline, occurrence: inlineMathOccurrence)
+                        ),
+                        replacement: AttributedString(latexText)
+                    ) {
+                        InlineMath(latexText: latexText)
+                    }
+                }
+                inlineMathOccurrence += 1
+            case .display:
+                let identifier = placeholderSegment.match.identifier
+                guard mathContext.displayMathStorage[identifier] != nil else {
+                    textContent += TextContent(.string(String(text[placeholderSegment.range])))
+                    searchRange = placeholderSegment.range.upperBound..<text.endIndex
+                    continue
+                }
+
+                textContent += MarkdownTextEmbeddingViewFactory.makeTextContent(
                     id: MarkdownTextInlineViewIdentifier(
                         markup: sourceMarkup,
-                        role: .inlineMath(occurrence: inlineMathOccurrence)
+                        role: .math(kind: .display, occurrence: displayMathOccurrence)
                     ),
-                    replacement: AttributedString(placeholderMatch.latexText)
+                    replacement: nil,
+                    componentSpacing: configuration.componentSpacing,
+                    sizing: .fittingLineFragment
                 ) {
-                    InlineMath(latexText: placeholderMatch.latexText)
+                    MarkdownDisplayMathView(mathIdentifier: identifier)
+                        .id(identifier)
                 }
+                displayMathOccurrence += 1
             }
-            inlineMathOccurrence += 1
-            searchRange = placeholderMatch.range.upperBound..<text.endIndex
+
+            searchRange = placeholderSegment.range.upperBound..<text.endIndex
         }
 
         if searchRange.lowerBound < text.endIndex {
@@ -47,30 +79,6 @@ extension MarkdownTextConverter {
 
         return textContent
     }
-}
-
-private extension MarkdownTextConverter {
-    func firstInlineMathPlaceholderMatch(
-        in text: String,
-        range: Range<String.Index>,
-        inlineMathStorage: [UUID: String]
-    ) -> InlineMathPlaceholderMatch? {
-        inlineMathStorage
-            .compactMap { identifier, latexText -> InlineMathPlaceholderMatch? in
-                let placeholder = MarkdownMathPreprocessor.inlinePlaceholder(for: identifier)
-                guard let range = text.range(of: placeholder, range: range) else {
-                    return nil
-                }
-
-                return InlineMathPlaceholderMatch(range: range, latexText: latexText)
-            }
-            .min { $0.range.lowerBound < $1.range.lowerBound }
-    }
-}
-
-private struct InlineMathPlaceholderMatch {
-    var range: Range<String.Index>
-    var latexText: String
 }
 
 #endif

--- a/Sources/MarkdownView/Rendering/MarkdownText/Semantics/MarkdownTextInlineViewIdentifier.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownText/Semantics/MarkdownTextInlineViewIdentifier.swift
@@ -8,11 +8,16 @@
 import Markdown
 
 struct MarkdownTextInlineViewIdentifier: Hashable {
+    enum MathKind: Hashable {
+        case inline
+        case display
+    }
+
     enum Role: Hashable {
         case blockAttachment
         case customLink
-        case inlineMath(occurrence: Int)
         case listCheckbox
+        case math(kind: MathKind, occurrence: Int)
         case thematicBreak
     }
 

--- a/Sources/MarkdownView/Rendering/MarkdownView/MarkdownNodes/InlineMathOrText.swift
+++ b/Sources/MarkdownView/Rendering/MarkdownView/MarkdownNodes/InlineMathOrText.swift
@@ -31,11 +31,19 @@ struct InlineMathOrText {
                 nodeViews.append(MarkdownNodeView(normalText))
             }
 
-            nodeViews.append(
-                MarkdownNodeView {
+            switch mathSegment.kind {
+            case .inline:
+                nodeViews.append(MarkdownNodeView {
                     InlineMath(latexText: mathSegment.latexText)
+                })
+            case .display:
+                if let identifier = mathSegment.identifier {
+                    nodeViews.append(MarkdownNodeView {
+                        MarkdownDisplayMathView(mathIdentifier: identifier)
+                            .id(identifier)
+                    })
                 }
-            )
+            }
 
             processingIndex = mathSegment.range.upperBound
         }
@@ -55,19 +63,23 @@ struct InlineMathOrText {
 #if ENABLE_MATH_RENDERING
 fileprivate extension InlineMathOrText {
     struct MathSegment {
+        var kind: MarkdownMathPreprocessor.PlaceholderKind
         var range: Range<String.Index>
         var latexText: String
+        var identifier: UUID?
     }
 
     func mathSegments(mathContext: MarkdownMathContext?) -> [MathSegment] {
-        let placeholderSegments = inlinePlaceholderSegments(mathContext: mathContext)
+        let placeholderSegments = mathPlaceholderSegments(mathContext: mathContext)
         let parsedSegments = MathParser(text: text)
             .mathRepresentations
             .lazy
             .map {
                 MathSegment(
+                    kind: .inline,
                     range: $0.range,
-                    latexText: String(text[$0.range])
+                    latexText: String(text[$0.range]),
+                    identifier: nil
                 )
             }
             .filter { parsedSegment in
@@ -80,28 +92,33 @@ fileprivate extension InlineMathOrText {
             .sorted { $0.range.lowerBound < $1.range.lowerBound }
     }
 
-    func inlinePlaceholderSegments(mathContext: MarkdownMathContext?) -> [MathSegment] {
-        guard let inlineMathStorage = mathContext?.inlineMathStorage else {
-            return []
-        }
+    func mathPlaceholderSegments(mathContext: MarkdownMathContext?) -> [MathSegment] {
+        MarkdownMathPreprocessor.placeholderSegments(in: text).compactMap { placeholderSegment in
+            switch placeholderSegment.match.kind {
+            case .inline:
+                guard let latexText = mathContext?.inlineMathStorage[placeholderSegment.match.identifier] else {
+                    return nil
+                }
 
-        var mathSegments: [MathSegment] = []
-        for (identifier, latexText) in inlineMathStorage {
-            let placeholder = MarkdownMathPreprocessor.inlinePlaceholder(for: identifier)
-            var searchRange = text.startIndex..<text.endIndex
-
-            while let placeholderRange = text.range(of: placeholder, range: searchRange) {
-                mathSegments.append(
-                    MathSegment(
-                        range: placeholderRange,
-                        latexText: latexText
-                    )
+                return MathSegment(
+                    kind: .inline,
+                    range: placeholderSegment.range,
+                    latexText: latexText,
+                    identifier: placeholderSegment.match.identifier
                 )
-                searchRange = placeholderRange.upperBound..<text.endIndex
+            case .display:
+                guard let latexText = mathContext?.displayMathStorage[placeholderSegment.match.identifier] else {
+                    return nil
+                }
+
+                return MathSegment(
+                    kind: .display,
+                    range: placeholderSegment.range,
+                    latexText: latexText,
+                    identifier: placeholderSegment.match.identifier
+                )
             }
         }
-
-        return mathSegments
     }
 }
 #endif

--- a/Tests/MarkdownViewTests/MarkdownTextConverterTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownTextConverterTests.swift
@@ -129,6 +129,52 @@ struct MarkdownTextConverterTests {
         #expect(!textContent.plainText.contains("markdownview-math(display:"))
         #expect(!textContent.plainText.contains("$$"))
     }
+
+    @Test("Converts display math followed by inline text to embedded content")
+    @MainActor
+    func convertsDisplayMathFollowedByInlineTextToEmbeddedContent() {
+        let preprocessingResult = MarkdownMathPreprocessor()
+            .preprocessingResult(
+                for: #"""
+                1. **Sum of a Geometric Series**:
+                    \[ S_n = a \frac{1-r^n}{1-r} \] (for \( r \neq 1 \))
+                """#
+            )
+
+        let textContent = Self.makeTextContent(
+            markdown: preprocessingResult.markdown,
+            mathContext: preprocessingResult.context,
+            parseOptions: []
+        )
+
+        #expect(textContent.embeddedViewCount == 2)
+        #expect(!textContent.plainText.contains("markdownview-math(display:"))
+        #expect(textContent.plainText.contains("(for "))
+    }
+
+    @Test("Distinguishes math embedding identities by kind and occurrence")
+    @MainActor
+    func distinguishesMathEmbeddingIdentitiesByKindAndOccurrence() throws {
+        let document = Document(parsing: "Math placeholders")
+        let paragraph = try #require(Array(document.children).first as? Paragraph)
+        let text = try #require(Array(paragraph.children).first as? Markdown.Text)
+
+        let firstDisplayIdentifier = MarkdownTextInlineViewIdentifier(
+            markup: text,
+            role: .math(kind: .display, occurrence: 0)
+        )
+        let secondDisplayIdentifier = MarkdownTextInlineViewIdentifier(
+            markup: text,
+            role: .math(kind: .display, occurrence: 1)
+        )
+        let firstInlineIdentifier = MarkdownTextInlineViewIdentifier(
+            markup: text,
+            role: .math(kind: .inline, occurrence: 0)
+        )
+
+        #expect(firstDisplayIdentifier != secondDisplayIdentifier)
+        #expect(firstDisplayIdentifier != firstInlineIdentifier)
+    }
     #endif
 
     @Test("Aligns list continuation paragraphs with item body")

--- a/Tests/MarkdownViewTests/MathExtractionTests.swift
+++ b/Tests/MarkdownViewTests/MathExtractionTests.swift
@@ -306,6 +306,20 @@ struct MathExtractionTests {
     }
 
     @Test
+    func testMathPreprocessingFindsDisplayPlaceholderWithTrailingInlineText() async throws {
+        let markdown = #"""
+        1. **Sum of a Geometric Series**:
+            \[ S_n = a \frac{1-r^n}{1-r} \] (for \( r \neq 1 \))
+        """#
+        let result = processMarkdownParsingRanges(in: markdown)
+        let placeholderSegments = MarkdownMathPreprocessor.placeholderSegments(in: result.markdown)
+
+        #expect(result.displayMathStorage.count == 1)
+        #expect(result.inlineMathStorage.count == 1)
+        #expect(placeholderSegments.map(\.match.kind) == [.display, .inline])
+    }
+
+    @Test
     func testMathPreprocessingPreservesEscapedBracketPunctuation() async throws {
         let markdown = #"Escaped punctuation: \*literal asterisks\*, \[literal brackets\], and \`literal backticks\`."#
         let result = processMarkdownParsingRanges(in: markdown)


### PR DESCRIPTION
Closes #107

### Topic

Preprocessed math representation followed by normal plain text could be rendered as raw intermediate representation

### Comparison

<img width="49%" src="https://github.com/user-attachments/assets/d5deb966-8961-4742-a616-a019bb69efe9" />
<img width="49%" src="https://github.com/user-attachments/assets/06d512e1-3833-496b-a070-275159f19582" />

The first expression is using display math while the second is inline math so it's placed in a new line (this is expected behavior)