### PR TITLE
Fix and silence the warning introduced in Swift 6.4

### DIFF
--- a/Sources/MarkdownView/Styles/Code Blocks/DefaultCodeBlockStyle.swift
+++ b/Sources/MarkdownView/Styles/Code Blocks/DefaultCodeBlockStyle.swift
@@ -194,7 +194,7 @@ fileprivate struct DefaultMarkdownCodeBlock: View {
             #elseif os(iOS) || os(visionOS)
             UIPasteboard.general.string = codeBlockConfiguration.code
             #endif
-            Task {
+            _ = Task {
                 withAnimation {
                     codeCopied = true
                 }


### PR DESCRIPTION
Fix and silence the warning introduced in Swift 6.4:
<img width="940" height="242" alt="622485397-4b4c2752-5b0d-44c5-bf19-109aafac1d66" src="https://github.com/user-attachments/assets/376cd4b4-6df7-48f5-8a73-959c478b2313" />

- #156 