### PR TITLE
Add versioned DocC publishing

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,59 +1,72 @@
-name: Generate Documentations
+name: Generate Documentation
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
+    tags: ['[0-9]*.[0-9]*.[0-9]*']
+  workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-jobs:
-  publish-docs:
-    env: # Environment Variables
-      SCHEME_NAME: MarkdownView
-      HOSTING_BASE_PATH: MarkdownView
-    environment: # Github Page environments
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-latest
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
+jobs:
+  build:
+    name: Build DocC site
+    runs-on: macos-26
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        
-      - name: Set up Xcode
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Restore versioned documentation cache
+        uses: actions/cache@v6
+        with:
+          path: .docs/cache/versioned-docc
+          key: versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-${{ github.ref_type }}-${{ github.sha }}
+          restore-keys: |
+            versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-
+            versioned-docc-${{ runner.os }}-
+
+      - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: '26.3'
 
-      - name: Build DocC archive
-        id: build-docs
+      - name: Prepare Xcode
         run: |
-          xcodebuild \
-            docbuild \
-            -scheme $SCHEME_NAME \
-            -destination "platform=macOS" \
-            -derivedDataPath build-docs
-          ARCHIVE=$(find build-docs/Build/Products -name "$SCHEME_NAME.doccarchive" -type d | head -n1)
-          echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          swift --version
+        shell: bash
 
-      - name: Process DocC archive
-        run: |
-          xcrun docc process-archive \
-            transform-for-static-hosting "${{ steps.build-docs.outputs.archive }}" \
-            --output-path docs \
-            --hosting-base-path $HOSTING_BASE_PATH
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload Pages artifacts
-        uses: actions/upload-pages-artifact@v3
+      - name: Build versioned DocC site
+        uses: DocCLab/VersionedDocC@0.0.13
         with:
-          path: docs
+          config: .vdc.json
 
-      - id: deployment
-        name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: .docs/build/versioned-site/MarkdownView
+
+  deploy:
+    name: Deploy DocC site
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,8 +1,8 @@
-name: Generate Documentation
+name: Generate Documentations
 
 on:
   push:
-    branches: [main]
+    branches: ["main"]
     tags: ['[0-9]*.[0-9]*.[0-9]*']
   workflow_dispatch:
 
@@ -16,11 +16,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build DocC site
-    runs-on: macos-26
+  publish-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-latest
+
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -34,39 +38,24 @@ jobs:
             versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-
             versioned-docc-${{ runner.os }}-
 
-      - name: Select Xcode
+      - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.3'
-
-      - name: Prepare Xcode
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
-          swift --version
-        shell: bash
+          xcode-version: latest
 
       - name: Build versioned DocC site
         uses: DocCLab/VersionedDocC@0.0.13
         with:
           config: .vdc.json
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifacts
+        uses: actions/upload-pages-artifact@v3
         with:
           path: .docs/build/versioned-site/MarkdownView
 
-  deploy:
-    name: Deploy DocC site
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - id: deployment
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.docs/
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/.vdc.json
+++ b/.vdc.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DocCLab/VersionedDocC/0.0.13/Schema/VersionedDocC.schema.json",
+  "schemaVersion": 1,
+  "projectName": "MarkdownView",
+  "moduleName": "MarkdownView",
+  "modulePath": "markdownview",
+  "targetName": "MarkdownView",
+  "catalogPath": "Sources/MarkdownView/Documentation.docc",
+  "hostingBasePath": "/MarkdownView",
+  "defaultVersion": "main",
+  "releasePolicy": {
+    "latest": 2,
+    "development": {
+      "name": "main",
+      "ref": "HEAD"
+    }
+  },
+  "sourceRepository": "https://github.com/LiYanan2004/MarkdownView",
+  "buildArguments": [
+    "--disable-index-store",
+    "--disable-dependency-cache",
+    "--disable-prefetching"
+  ],
+  "allowedModules": [
+    "MarkdownView"
+  ],
+  "symbolGraph": {
+    "minimumAccessLevel": "public",
+    "skipProtocolImplementations": true
+  },
+  "apiChanges": {
+    "pageSize": 10
+  }
+}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Powered by [swift-markdown](https://github.com/swiftlang/swift-markdown), fully 
 You can view documentation on:
 
 - [main @ Swift Package Index](https://swiftpackageindex.com/LiYanan2004/MarkdownView/main/documentation/MarkdownView)
-- [main @ GitHub Pages](https://liyanan2004.github.io/MarkdownView/documentation/markdownview/)
+- [main @ GitHub Pages](https://liyanan2004.github.io/MarkdownView/main/documentation/markdownview/)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- add a `.vdc.json` configuration that publishes the development branch and the latest two release series
- upgrade the existing GitHub Pages workflow from a single DocC archive to a cached VersionedDocC build
- add version selection, version-correct GitHub source links, and adjacent-version public API changes
- update the README to use the stable versioned GitHub Pages URL

The release list is selected dynamically with `releasePolicy.latest: 2`; it currently resolves to `main`, `3.0.0`, and `2.7.0` without hard-coding release tags in the configuration.

## Why

The existing Pages workflow only publishes the current `main` documentation. VersionedDocC keeps immutable release documentation available under stable URLs and generates API comparisons from the releases' public symbol graphs.

## Preview

- [Versioned documentation](https://docclab.github.io/MarkdownView/main/documentation/markdownview/)
- [API changes](https://docclab.github.io/MarkdownView/main/changes/)
- [Reference fork](https://github.com/DocCLab/MarkdownView)

## Validation

- built all three documentation versions locally with VersionedDocC 0.0.13
- verified the version selector, API comparison selector, and GitHub source link in a local browser preview
- verified `2.7.0 → 3.0.0` produces 78 added, 17 modified, and 37 removed public API entries
- deployed the fork through the updated workflow: https://github.com/DocCLab/MarkdownView/actions/runs/31041404655
- confirmed the fork's root, Changes page, and all three documentation versions return HTTP 200
